### PR TITLE
Implement update hash

### DIFF
--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -138,7 +138,7 @@ func (r *ReconcileDeployment) Reconcile(request reconcile.Request) (reconcile.Re
 
 	// Update the desired state of the Deployment in a DeepCopy
 	copy := instance.DeepCopy()
-	updateHash(copy, hash)
+	setConfigHash(copy, hash)
 	addFinalizer(copy)
 
 	// If the desired state doesn't match the existing state, update it

--- a/pkg/controller/deployment/hash.go
+++ b/pkg/controller/deployment/hash.go
@@ -36,9 +36,9 @@ func calculateConfigHash(children []metav1.Object) (string, error) {
 	return "", nil
 }
 
-// updateHash upates the configuration hash of the given Deployment to the
+// setConfigHash upates the configuration hash of the given Deployment to the
 // given string
-func updateHash(obj *appsv1.Deployment, hash string) {
+func setConfigHash(obj *appsv1.Deployment, hash string) {
 	// Get the existing annotations
 	annotations := obj.Spec.Template.GetAnnotations()
 	if annotations == nil {

--- a/pkg/controller/deployment/hash_test.go
+++ b/pkg/controller/deployment/hash_test.go
@@ -79,7 +79,7 @@ var _ = Describe("Wave hash Suite", func() {
 		})
 	})
 
-	Context("updateHash", func() {
+	Context("setConfigHash", func() {
 		var deployment *appsv1.Deployment
 
 		BeforeEach(func() {
@@ -87,7 +87,7 @@ var _ = Describe("Wave hash Suite", func() {
 		})
 
 		It("sets the hash annotation to the provided value", func() {
-			updateHash(deployment, "1234")
+			setConfigHash(deployment, "1234")
 
 			podAnnotations := deployment.Spec.Template.GetAnnotations()
 			Expect(podAnnotations).NotTo(BeNil())
@@ -106,8 +106,8 @@ var _ = Describe("Wave hash Suite", func() {
 			podAnnotations["existing"] = "annotation"
 			deployment.Spec.Template.SetAnnotations(podAnnotations)
 
-			// Update the hash
-			updateHash(deployment, "1234")
+			// Set the config hash
+			setConfigHash(deployment, "1234")
 
 			// Check the existing annotation is still in place
 			podAnnotations = deployment.Spec.Template.GetAnnotations()


### PR DESCRIPTION
Implements the `updateHash` method:
- Fetch Pod Template annotations
- Initialize them if they are `nil`
- Set the `configHashAnnotation` to the desired hash value