### PR TITLE
Update command in Manager StatefulSet

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -42,7 +42,7 @@ spec:
     spec:
       containers:
       - command:
-        - /root/manager
+        - /bin/manager
         image: controller:latest
         imagePullPolicy: Always
         name: manager


### PR DESCRIPTION
Noticed this when trying to get Wave running locally in Minikube. The Dockerfile and wercker.yml put the command in `/bin` and not `/root`.