### PR TITLE
Handle env section in deployment yaml

### DIFF
--- a/pkg/core/children_test.go
+++ b/pkg/core/children_test.go
@@ -108,7 +108,7 @@ var _ = Describe("Wave children Suite", func() {
 			Expect(currentChildren).To(ContainElement(ConfigObject{
 				k8sObject:    cm1,
 				singleFields: false,
-				fieldKeys:    map[string]struct{}{},
+				fieldKeys:    map[string]ConfigField{},
 			}))
 		})
 
@@ -116,7 +116,7 @@ var _ = Describe("Wave children Suite", func() {
 			Expect(currentChildren).To(ContainElement(ConfigObject{
 				k8sObject:    cm2,
 				singleFields: false,
-				fieldKeys:    map[string]struct{}{},
+				fieldKeys:    map[string]ConfigField{},
 			}))
 		})
 
@@ -124,17 +124,10 @@ var _ = Describe("Wave children Suite", func() {
 			Expect(currentChildren).To(ContainElement(ConfigObject{
 				k8sObject:    cm3,
 				singleFields: true,
-				fieldKeys: map[string]struct{}{
-					"key1": struct{}{},
-					"key2": struct{}{},
-				},
-			}))
-			Expect(currentChildren).To(ContainElement(ConfigObject{
-				k8sObject:    cm3,
-				singleFields: true,
-				fieldKeys: map[string]struct{}{
-					"key1": struct{}{},
-					"key2": struct{}{},
+				fieldKeys: map[string]ConfigField{
+					"key1": ConfigField{optional: false},
+					"key2": ConfigField{optional: false},
+					"key4": ConfigField{optional: true},
 				},
 			}))
 		})
@@ -143,7 +136,7 @@ var _ = Describe("Wave children Suite", func() {
 			Expect(currentChildren).To(ContainElement(ConfigObject{
 				k8sObject:    s1,
 				singleFields: false,
-				fieldKeys:    map[string]struct{}{},
+				fieldKeys:    map[string]ConfigField{},
 			}))
 		})
 
@@ -151,7 +144,7 @@ var _ = Describe("Wave children Suite", func() {
 			Expect(currentChildren).To(ContainElement(ConfigObject{
 				k8sObject:    s2,
 				singleFields: false,
-				fieldKeys:    map[string]struct{}{},
+				fieldKeys:    map[string]ConfigField{},
 			}))
 		})
 
@@ -159,17 +152,10 @@ var _ = Describe("Wave children Suite", func() {
 			Expect(currentChildren).To(ContainElement(ConfigObject{
 				k8sObject:    s3,
 				singleFields: true,
-				fieldKeys: map[string]struct{}{
-					"key1": struct{}{},
-					"key2": struct{}{},
-				},
-			}))
-			Expect(currentChildren).To(ContainElement(ConfigObject{
-				k8sObject:    s3,
-				singleFields: true,
-				fieldKeys: map[string]struct{}{
-					"key1": struct{}{},
-					"key2": struct{}{},
+				fieldKeys: map[string]ConfigField{
+					"key1": ConfigField{optional: false},
+					"key2": ConfigField{optional: false},
+					"key4": ConfigField{optional: true},
 				},
 			}))
 		})
@@ -192,8 +178,8 @@ var _ = Describe("Wave children Suite", func() {
 	Context("getChildNamesByType", func() {
 		var configMaps map[string]struct{}
 		var secrets map[string]struct{}
-		var configMapKeyReferences map[string]map[string]struct{}
-		var secretKeyReferences map[string]map[string]struct{}
+		var configMapKeyReferences map[string]map[string]ConfigField
+		var secretKeyReferences map[string]map[string]ConfigField
 
 		BeforeEach(func() {
 			configMaps, secrets, configMapKeyReferences, secretKeyReferences = getChildNamesByType(deployment)
@@ -210,9 +196,14 @@ var _ = Describe("Wave children Suite", func() {
 		It("returns ConfigMaps referenced in Env", func() {
 			Expect(configMapKeyReferences).To(HaveKey(cm1.GetName()))
 			Expect(configMapKeyReferences[cm1.GetName()]).To(HaveKey("key1"))
+			Expect(configMapKeyReferences[cm1.GetName()]["key1"].optional).To(BeFalse())
 			Expect(configMapKeyReferences).To(HaveKey(cm3.GetName()))
 			Expect(configMapKeyReferences[cm3.GetName()]).To(HaveKey("key1"))
+			Expect(configMapKeyReferences[cm3.GetName()]["key1"].optional).To(BeFalse())
 			Expect(configMapKeyReferences[cm3.GetName()]).To(HaveKey("key2"))
+			Expect(configMapKeyReferences[cm3.GetName()]["key2"].optional).To(BeFalse())
+			Expect(configMapKeyReferences[cm3.GetName()]).To(HaveKey("key4"))
+			Expect(configMapKeyReferences[cm3.GetName()]["key4"].optional).To(BeTrue())
 		})
 
 		It("returns Secrets referenced in Volumes", func() {
@@ -226,9 +217,14 @@ var _ = Describe("Wave children Suite", func() {
 		It("returns Secrets referenced in Env", func() {
 			Expect(secretKeyReferences).To(HaveKey(s1.GetName()))
 			Expect(secretKeyReferences[s1.GetName()]).To(HaveKey("key1"))
+			Expect(configMapKeyReferences[s1.GetName()]["key1"].optional).To(BeFalse())
 			Expect(secretKeyReferences).To(HaveKey(s3.GetName()))
 			Expect(secretKeyReferences[s3.GetName()]).To(HaveKey("key1"))
+			Expect(configMapKeyReferences[s3.GetName()]["key1"].optional).To(BeFalse())
 			Expect(secretKeyReferences[s3.GetName()]).To(HaveKey("key2"))
+			Expect(configMapKeyReferences[s3.GetName()]["key2"].optional).To(BeFalse())
+			Expect(secretKeyReferences[s3.GetName()]).To(HaveKey("key4"))
+			Expect(configMapKeyReferences[s3.GetName()]["key4"].optional).To(BeTrue())
 		})
 
 		It("does not return extra children", func() {

--- a/pkg/core/handler_test.go
+++ b/pkg/core/handler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Pusher Ltd.
+Copyright 2018, 2019 Pusher Ltd.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -49,8 +49,10 @@ var _ = Describe("Wave controller Suite", func() {
 	var ownerRef metav1.OwnerReference
 	var cm1 *corev1.ConfigMap
 	var cm2 *corev1.ConfigMap
+	var cm3 *corev1.ConfigMap
 	var s1 *corev1.Secret
 	var s2 *corev1.Secret
+	var s3 *corev1.Secret
 
 	BeforeEach(func() {
 		mgr, err := manager.New(cfg, manager.Options{})
@@ -64,17 +66,23 @@ var _ = Describe("Wave controller Suite", func() {
 		// Create some configmaps and secrets
 		cm1 = utils.ExampleConfigMap1.DeepCopy()
 		cm2 = utils.ExampleConfigMap2.DeepCopy()
+		cm3 = utils.ExampleConfigMap3.DeepCopy()
 		s1 = utils.ExampleSecret1.DeepCopy()
 		s2 = utils.ExampleSecret2.DeepCopy()
+		s3 = utils.ExampleSecret3.DeepCopy()
 
 		m.Create(cm1).Should(Succeed())
 		m.Create(cm2).Should(Succeed())
+		m.Create(cm3).Should(Succeed())
 		m.Create(s1).Should(Succeed())
 		m.Create(s2).Should(Succeed())
+		m.Create(s3).Should(Succeed())
 		m.Get(cm1, timeout).Should(Succeed())
 		m.Get(cm2, timeout).Should(Succeed())
+		m.Get(cm3, timeout).Should(Succeed())
 		m.Get(s1, timeout).Should(Succeed())
 		m.Get(s2, timeout).Should(Succeed())
+		m.Get(s3, timeout).Should(Succeed())
 
 		deployment = utils.ExampleDeployment.DeepCopy()
 
@@ -147,7 +155,7 @@ var _ = Describe("Wave controller Suite", func() {
 			})
 
 			It("Adds OwnerReferences to all children", func() {
-				for _, obj := range []Object{cm1, cm2, s1, s2} {
+				for _, obj := range []Object{cm1, cm2, cm3, s1, s2, s3} {
 					m.Eventually(obj, timeout).Should(utils.WithOwnerReferences(ContainElement(ownerRef)))
 				}
 			})
@@ -168,7 +176,7 @@ var _ = Describe("Wave controller Suite", func() {
 					return event.Message
 				}
 
-				hashMessage := "Configuration hash updated to 198df8455a4fd702fc0c7fdfa4bdb213363b96240bfd48b7b098d936499315a1"
+				hashMessage := "Configuration hash updated to ebabf80ef45218b27078a41ca16b35a4f91cb5672f389e520ae9da6ee3df3b1c"
 				m.Eventually(events, timeout).Should(utils.WithItems(ContainElement(WithTransform(eventMessage, Equal(hashMessage)))))
 			})
 
@@ -226,7 +234,7 @@ var _ = Describe("Wave controller Suite", func() {
 					})
 
 					It("Updates the config hash in the Pod Template", func() {
-						m.Eventually(deployment, timeout).ShouldNot(utils.WithAnnotations(HaveKeyWithValue(ConfigHashAnnotation, originalHash)))
+						m.Eventually(deployment, timeout).ShouldNot(utils.WithPodTemplateAnnotations(HaveKeyWithValue(ConfigHashAnnotation, originalHash)))
 					})
 				})
 
@@ -244,7 +252,43 @@ var _ = Describe("Wave controller Suite", func() {
 					})
 
 					It("Updates the config hash in the Pod Template", func() {
-						m.Eventually(deployment, timeout).ShouldNot(utils.WithAnnotations(HaveKeyWithValue(ConfigHashAnnotation, originalHash)))
+						m.Eventually(deployment, timeout).ShouldNot(utils.WithPodTemplateAnnotations(HaveKeyWithValue(ConfigHashAnnotation, originalHash)))
+					})
+				})
+
+				Context("A ConfigMap Env for a key being used is updated", func() {
+					BeforeEach(func() {
+						m.Get(cm3, timeout).Should(Succeed())
+						cm3.Data["key1"] = "modified"
+						m.Update(cm3).Should(Succeed())
+
+						_, err := h.HandleDeployment(deployment)
+						Expect(err).NotTo(HaveOccurred())
+
+						// Get the updated Deployment
+						m.Get(deployment, timeout).Should(Succeed())
+					})
+
+					It("Updates the config hash in the Pod Template", func() {
+						m.Eventually(deployment, timeout).ShouldNot(utils.WithPodTemplateAnnotations(HaveKeyWithValue(ConfigHashAnnotation, originalHash)))
+					})
+				})
+
+				Context("A ConfigMap Env for a key that is not being used is updated", func() {
+					BeforeEach(func() {
+						m.Get(cm3, timeout).Should(Succeed())
+						cm3.Data["key3"] = "modified"
+						m.Update(cm3).Should(Succeed())
+
+						_, err := h.HandleDeployment(deployment)
+						Expect(err).NotTo(HaveOccurred())
+
+						// Get the updated Deployment
+						m.Get(deployment, timeout).Should(Succeed())
+					})
+
+					It("Does not update the config hash in the Pod Template", func() {
+						m.Eventually(deployment, timeout).Should(utils.WithPodTemplateAnnotations(HaveKeyWithValue(ConfigHashAnnotation, originalHash)))
 					})
 				})
 
@@ -265,7 +309,7 @@ var _ = Describe("Wave controller Suite", func() {
 					})
 
 					It("Updates the config hash in the Pod Template", func() {
-						m.Eventually(deployment, timeout).ShouldNot(utils.WithAnnotations(HaveKeyWithValue(ConfigHashAnnotation, originalHash)))
+						m.Eventually(deployment, timeout).ShouldNot(utils.WithPodTemplateAnnotations(HaveKeyWithValue(ConfigHashAnnotation, originalHash)))
 					})
 				})
 
@@ -286,7 +330,49 @@ var _ = Describe("Wave controller Suite", func() {
 					})
 
 					It("Updates the config hash in the Pod Template", func() {
-						m.Eventually(deployment, timeout).ShouldNot(utils.WithAnnotations(HaveKeyWithValue(ConfigHashAnnotation, originalHash)))
+						m.Eventually(deployment, timeout).ShouldNot(utils.WithPodTemplateAnnotations(HaveKeyWithValue(ConfigHashAnnotation, originalHash)))
+					})
+				})
+
+				Context("A Secret Env for a key being used is updated", func() {
+					BeforeEach(func() {
+						m.Get(s3, timeout).Should(Succeed())
+						if s3.StringData == nil {
+							s3.StringData = make(map[string]string)
+						}
+						s3.StringData["key1"] = "modified"
+						m.Update(s3).Should(Succeed())
+
+						_, err := h.HandleDeployment(deployment)
+						Expect(err).NotTo(HaveOccurred())
+
+						// Get the updated Deployment
+						m.Get(deployment, timeout).Should(Succeed())
+					})
+
+					It("Updates the config hash in the Pod Template", func() {
+						m.Eventually(deployment, timeout).ShouldNot(utils.WithPodTemplateAnnotations(HaveKeyWithValue(ConfigHashAnnotation, originalHash)))
+					})
+				})
+
+				Context("A Secret Env for a key that is not being used is updated", func() {
+					BeforeEach(func() {
+						m.Get(s3, timeout).Should(Succeed())
+						if s3.StringData == nil {
+							s3.StringData = make(map[string]string)
+						}
+						s3.StringData["key3"] = "modified"
+						m.Update(s3).Should(Succeed())
+
+						_, err := h.HandleDeployment(deployment)
+						Expect(err).NotTo(HaveOccurred())
+
+						// Get the updated Deployment
+						m.Get(deployment, timeout).Should(Succeed())
+					})
+
+					It("Does not update the config hash in the Pod Template", func() {
+						m.Eventually(deployment, timeout).Should(utils.WithPodTemplateAnnotations(HaveKeyWithValue(ConfigHashAnnotation, originalHash)))
 					})
 				})
 			})

--- a/pkg/core/hash_test.go
+++ b/pkg/core/hash_test.go
@@ -89,10 +89,10 @@ var _ = Describe("Wave hash Suite", func() {
 
 		It("returns a different hash when an all-field child's data is updated", func() {
 			c := []ConfigObject{
-				{k8sObject: cm1, singleFields: false, fieldKeys: map[string]struct{}{}},
-				{k8sObject: cm2, singleFields: false, fieldKeys: map[string]struct{}{}},
-				{k8sObject: s1, singleFields: false, fieldKeys: map[string]struct{}{}},
-				{k8sObject: s2, singleFields: false, fieldKeys: map[string]struct{}{}},
+				{k8sObject: cm1, singleFields: false, fieldKeys: map[string]ConfigField{}},
+				{k8sObject: cm2, singleFields: false, fieldKeys: map[string]ConfigField{}},
+				{k8sObject: s1, singleFields: false, fieldKeys: map[string]ConfigField{}},
+				{k8sObject: s2, singleFields: false, fieldKeys: map[string]ConfigField{}},
 			}
 
 			h1, err := calculateConfigHash(c)
@@ -108,10 +108,10 @@ var _ = Describe("Wave hash Suite", func() {
 
 		It("returns a different hash when an all-field child's data is updated", func() {
 			c := []ConfigObject{
-				{k8sObject: cm1, singleFields: false, fieldKeys: map[string]struct{}{}},
-				{k8sObject: cm2, singleFields: false, fieldKeys: map[string]struct{}{}},
-				{k8sObject: s1, singleFields: false, fieldKeys: map[string]struct{}{}},
-				{k8sObject: s2, singleFields: false, fieldKeys: map[string]struct{}{}},
+				{k8sObject: cm1, singleFields: false, fieldKeys: map[string]ConfigField{}},
+				{k8sObject: cm2, singleFields: false, fieldKeys: map[string]ConfigField{}},
+				{k8sObject: s1, singleFields: false, fieldKeys: map[string]ConfigField{}},
+				{k8sObject: s2, singleFields: false, fieldKeys: map[string]ConfigField{}},
 			}
 
 			h1, err := calculateConfigHash(c)
@@ -127,16 +127,16 @@ var _ = Describe("Wave hash Suite", func() {
 
 		It("returns a different hash when a single-field child's data is updated", func() {
 			c := []ConfigObject{
-				{k8sObject: cm1, singleFields: true, fieldKeys: map[string]struct{}{
-					"key1": struct{}{},
+				{k8sObject: cm1, singleFields: true, fieldKeys: map[string]ConfigField{
+					"key1": ConfigField{optional: false},
 				},
 				},
-				{k8sObject: cm2, singleFields: false, fieldKeys: map[string]struct{}{}},
-				{k8sObject: s1, singleFields: true, fieldKeys: map[string]struct{}{
-					"key1": struct{}{},
+				{k8sObject: cm2, singleFields: false, fieldKeys: map[string]ConfigField{}},
+				{k8sObject: s1, singleFields: true, fieldKeys: map[string]ConfigField{
+					"key1": ConfigField{optional: false},
 				},
 				},
-				{k8sObject: s2, singleFields: false, fieldKeys: map[string]struct{}{}},
+				{k8sObject: s2, singleFields: false, fieldKeys: map[string]ConfigField{}},
 			}
 
 			h1, err := calculateConfigHash(c)
@@ -152,18 +152,47 @@ var _ = Describe("Wave hash Suite", func() {
 			Expect(h2).NotTo(Equal(h1))
 		})
 
+		It("returns a different hash when an optional single-field child's data is created", func() {
+			c := []ConfigObject{
+				{k8sObject: cm1, singleFields: true, fieldKeys: map[string]ConfigField{
+					"key1": ConfigField{optional: false},
+					"key4": ConfigField{optional: true},
+				},
+				},
+				{k8sObject: cm2, singleFields: false, fieldKeys: map[string]ConfigField{}},
+				{k8sObject: s1, singleFields: true, fieldKeys: map[string]ConfigField{
+					"key1": ConfigField{optional: false},
+					"key4": ConfigField{optional: true},
+				},
+				},
+				{k8sObject: s2, singleFields: false, fieldKeys: map[string]ConfigField{}},
+			}
+
+			h1, err := calculateConfigHash(c)
+			Expect(err).NotTo(HaveOccurred())
+
+			cm1.Data["key4"] = "modified"
+			m.Update(cm1).Should(Succeed())
+			s1.Data["key4"] = []byte("modified")
+			m.Update(s1).Should(Succeed())
+			h2, err := calculateConfigHash(c)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(h2).NotTo(Equal(h1))
+		})
+
 		It("returns the same hash when a single-field child's data is updated but not for that field", func() {
 			c := []ConfigObject{
-				{k8sObject: cm1, singleFields: true, fieldKeys: map[string]struct{}{
-					"key1": struct{}{},
+				{k8sObject: cm1, singleFields: true, fieldKeys: map[string]ConfigField{
+					"key1": ConfigField{optional: false},
 				},
 				},
-				{k8sObject: cm2, singleFields: false, fieldKeys: map[string]struct{}{}},
-				{k8sObject: s1, singleFields: true, fieldKeys: map[string]struct{}{
-					"key1": struct{}{},
+				{k8sObject: cm2, singleFields: false, fieldKeys: map[string]ConfigField{}},
+				{k8sObject: s1, singleFields: true, fieldKeys: map[string]ConfigField{
+					"key1": ConfigField{optional: false},
 				},
 				},
-				{k8sObject: s2, singleFields: false, fieldKeys: map[string]struct{}{}},
+				{k8sObject: s2, singleFields: false, fieldKeys: map[string]ConfigField{}},
 			}
 
 			h1, err := calculateConfigHash(c)
@@ -181,10 +210,10 @@ var _ = Describe("Wave hash Suite", func() {
 
 		It("returns the same hash when a child's metadata is updated", func() {
 			c := []ConfigObject{
-				{k8sObject: cm1, singleFields: false, fieldKeys: map[string]struct{}{}},
-				{k8sObject: cm2, singleFields: false, fieldKeys: map[string]struct{}{}},
-				{k8sObject: s1, singleFields: false, fieldKeys: map[string]struct{}{}},
-				{k8sObject: s2, singleFields: false, fieldKeys: map[string]struct{}{}},
+				{k8sObject: cm1, singleFields: false, fieldKeys: map[string]ConfigField{}},
+				{k8sObject: cm2, singleFields: false, fieldKeys: map[string]ConfigField{}},
+				{k8sObject: s1, singleFields: false, fieldKeys: map[string]ConfigField{}},
+				{k8sObject: s2, singleFields: false, fieldKeys: map[string]ConfigField{}},
 			}
 
 			h1, err := calculateConfigHash(c)
@@ -200,34 +229,34 @@ var _ = Describe("Wave hash Suite", func() {
 
 		It("returns the same hash independent of child ordering", func() {
 			c1 := []ConfigObject{
-				{k8sObject: cm1, singleFields: false, fieldKeys: map[string]struct{}{}},
-				{k8sObject: cm2, singleFields: false, fieldKeys: map[string]struct{}{}},
-				{k8sObject: cm3, singleFields: true, fieldKeys: map[string]struct{}{
-					"key1": struct{}{},
-					"key2": struct{}{},
+				{k8sObject: cm1, singleFields: false, fieldKeys: map[string]ConfigField{}},
+				{k8sObject: cm2, singleFields: false, fieldKeys: map[string]ConfigField{}},
+				{k8sObject: cm3, singleFields: true, fieldKeys: map[string]ConfigField{
+					"key1": ConfigField{optional: false},
+					"key2": ConfigField{optional: false},
 				},
 				},
-				{k8sObject: s1, singleFields: false, fieldKeys: map[string]struct{}{}},
-				{k8sObject: s2, singleFields: false, fieldKeys: map[string]struct{}{}},
-				{k8sObject: s3, singleFields: false, fieldKeys: map[string]struct{}{
-					"key1": struct{}{},
-					"key2": struct{}{},
+				{k8sObject: s1, singleFields: false, fieldKeys: map[string]ConfigField{}},
+				{k8sObject: s2, singleFields: false, fieldKeys: map[string]ConfigField{}},
+				{k8sObject: s3, singleFields: false, fieldKeys: map[string]ConfigField{
+					"key1": ConfigField{optional: false},
+					"key2": ConfigField{optional: false},
 				},
 				},
 			}
 			c2 := []ConfigObject{
-				{k8sObject: cm1, singleFields: false, fieldKeys: map[string]struct{}{}},
-				{k8sObject: s2, singleFields: false, fieldKeys: map[string]struct{}{}},
-				{k8sObject: s3, singleFields: false, fieldKeys: map[string]struct{}{
-					"key1": struct{}{},
-					"key2": struct{}{},
+				{k8sObject: cm1, singleFields: false, fieldKeys: map[string]ConfigField{}},
+				{k8sObject: s2, singleFields: false, fieldKeys: map[string]ConfigField{}},
+				{k8sObject: s3, singleFields: false, fieldKeys: map[string]ConfigField{
+					"key1": ConfigField{optional: false},
+					"key2": ConfigField{optional: false},
 				},
 				},
-				{k8sObject: cm2, singleFields: false, fieldKeys: map[string]struct{}{}},
-				{k8sObject: s1, singleFields: false, fieldKeys: map[string]struct{}{}},
-				{k8sObject: cm3, singleFields: true, fieldKeys: map[string]struct{}{
-					"key2": struct{}{},
-					"key1": struct{}{},
+				{k8sObject: cm2, singleFields: false, fieldKeys: map[string]ConfigField{}},
+				{k8sObject: s1, singleFields: false, fieldKeys: map[string]ConfigField{}},
+				{k8sObject: cm3, singleFields: true, fieldKeys: map[string]ConfigField{
+					"key2": ConfigField{optional: false},
+					"key1": ConfigField{optional: false},
 				},
 				},
 			}

--- a/pkg/core/owner_references.go
+++ b/pkg/core/owner_references.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Pusher Ltd.
+Copyright 2018, 2019 Pusher Ltd.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -55,13 +55,13 @@ func (h *Handler) removeOwnerReferences(obj *appsv1.Deployment, children []Objec
 // updateOwnerReferences determines which children need to have their
 // OwnerReferences added/updated and which need to have their OwnerReferences
 // removed and then performs all updates
-func (h *Handler) updateOwnerReferences(owner *appsv1.Deployment, existing, current []Object) error {
+func (h *Handler) updateOwnerReferences(owner *appsv1.Deployment, existing []Object, current []ConfigObject) error {
 	// Add an owner reference to each child object
 	errChan := make(chan error)
 	for _, obj := range current {
 		go func(child Object) {
 			errChan <- h.updateOwnerReference(owner, child)
-		}(obj)
+		}(obj.k8sObject)
 	}
 
 	// Return any errors encountered updating the child objects
@@ -110,7 +110,7 @@ func (h *Handler) updateOwnerReference(owner *appsv1.Deployment, child Object) e
 
 // getOrphans creates a slice of orphaned child objects that need their
 // OwnerReferences removing
-func getOrphans(existing, current []Object) []Object {
+func getOrphans(existing []Object, current []ConfigObject) []Object {
 	orphans := []Object{}
 	for _, child := range existing {
 		if !isIn(current, child) {
@@ -135,9 +135,9 @@ func getOwnerReference(obj *appsv1.Deployment) metav1.OwnerReference {
 }
 
 // isIn checks whether a child object exists within a slice of objects
-func isIn(list []Object, child Object) bool {
+func isIn(list []ConfigObject, child Object) bool {
 	for _, obj := range list {
-		if obj.GetUID() == child.GetUID() {
+		if obj.k8sObject.GetUID() == child.GetUID() {
 			return true
 		}
 	}

--- a/pkg/core/owner_references_test.go
+++ b/pkg/core/owner_references_test.go
@@ -151,11 +151,11 @@ var _ = Describe("Wave owner references Suite", func() {
 
 			existing := []Object{cm2, cm3, s1, s2}
 			current := []ConfigObject{
-				{k8sObject: cm1, singleFields: false, fieldKeys: map[string]struct{}{}},
-				{k8sObject: s1, singleFields: false, fieldKeys: map[string]struct{}{}},
-				{k8sObject: s3, singleFields: true, fieldKeys: map[string]struct{}{
-					"key1": struct{}{},
-					"key2": struct{}{},
+				{k8sObject: cm1, singleFields: false, fieldKeys: map[string]ConfigField{}},
+				{k8sObject: s1, singleFields: false, fieldKeys: map[string]ConfigField{}},
+				{k8sObject: s3, singleFields: true, fieldKeys: map[string]ConfigField{
+					"key1": ConfigField{optional: false},
+					"key2": ConfigField{optional: false},
 				},
 				},
 			}
@@ -234,10 +234,10 @@ var _ = Describe("Wave owner references Suite", func() {
 	Context("getOrphans", func() {
 		It("returns an empty list when current and existing match", func() {
 			current := []ConfigObject{
-				{k8sObject: cm1, singleFields: false, fieldKeys: map[string]struct{}{}},
-				{k8sObject: cm2, singleFields: false, fieldKeys: map[string]struct{}{}},
-				{k8sObject: s1, singleFields: false, fieldKeys: map[string]struct{}{}},
-				{k8sObject: s2, singleFields: false, fieldKeys: map[string]struct{}{}},
+				{k8sObject: cm1, singleFields: false, fieldKeys: map[string]ConfigField{}},
+				{k8sObject: cm2, singleFields: false, fieldKeys: map[string]ConfigField{}},
+				{k8sObject: s1, singleFields: false, fieldKeys: map[string]ConfigField{}},
+				{k8sObject: s2, singleFields: false, fieldKeys: map[string]ConfigField{}},
 			}
 			existing := []Object{cm1, cm2, s1, s2}
 			Expect(getOrphans(existing, current)).To(BeEmpty())
@@ -245,10 +245,10 @@ var _ = Describe("Wave owner references Suite", func() {
 
 		It("returns an empty list when existing is a subset of current", func() {
 			current := []ConfigObject{
-				{k8sObject: cm1, singleFields: false, fieldKeys: map[string]struct{}{}},
-				{k8sObject: cm2, singleFields: false, fieldKeys: map[string]struct{}{}},
-				{k8sObject: s1, singleFields: false, fieldKeys: map[string]struct{}{}},
-				{k8sObject: s2, singleFields: false, fieldKeys: map[string]struct{}{}},
+				{k8sObject: cm1, singleFields: false, fieldKeys: map[string]ConfigField{}},
+				{k8sObject: cm2, singleFields: false, fieldKeys: map[string]ConfigField{}},
+				{k8sObject: s1, singleFields: false, fieldKeys: map[string]ConfigField{}},
+				{k8sObject: s2, singleFields: false, fieldKeys: map[string]ConfigField{}},
 			}
 			existing := []Object{cm1, s2}
 			Expect(getOrphans(existing, current)).To(BeEmpty())
@@ -256,8 +256,8 @@ var _ = Describe("Wave owner references Suite", func() {
 
 		It("returns the correct objects when current is a subset of existing", func() {
 			current := []ConfigObject{
-				{k8sObject: cm1, singleFields: false, fieldKeys: map[string]struct{}{}},
-				{k8sObject: s2, singleFields: false, fieldKeys: map[string]struct{}{}},
+				{k8sObject: cm1, singleFields: false, fieldKeys: map[string]ConfigField{}},
+				{k8sObject: s2, singleFields: false, fieldKeys: map[string]ConfigField{}},
 			}
 			existing := []Object{cm1, cm2, s1, s2}
 			orphans := getOrphans(existing, current)
@@ -268,14 +268,14 @@ var _ = Describe("Wave owner references Suite", func() {
 		Context("when current contains multiple singleField entries", func() {
 			It("returns an empty list when current and existing match", func() {
 				current := []ConfigObject{
-					{k8sObject: cm1, singleFields: false, fieldKeys: map[string]struct{}{}},
-					{k8sObject: cm2, singleFields: true, fieldKeys: map[string]struct{}{
-						"key1": struct{}{},
-						"key2": struct{}{},
+					{k8sObject: cm1, singleFields: false, fieldKeys: map[string]ConfigField{}},
+					{k8sObject: cm2, singleFields: true, fieldKeys: map[string]ConfigField{
+						"key1": ConfigField{optional: false},
+						"key2": ConfigField{optional: false},
 					},
 					},
-					{k8sObject: s1, singleFields: false, fieldKeys: map[string]struct{}{}},
-					{k8sObject: s2, singleFields: false, fieldKeys: map[string]struct{}{}},
+					{k8sObject: s1, singleFields: false, fieldKeys: map[string]ConfigField{}},
+					{k8sObject: s2, singleFields: false, fieldKeys: map[string]ConfigField{}},
 				}
 				existing := []Object{cm1, cm2, s1, s2}
 				Expect(getOrphans(existing, current)).To(BeEmpty())
@@ -283,14 +283,14 @@ var _ = Describe("Wave owner references Suite", func() {
 
 			It("returns an empty list when existing is a subset of current", func() {
 				current := []ConfigObject{
-					{k8sObject: cm1, singleFields: false, fieldKeys: map[string]struct{}{}},
-					{k8sObject: cm2, singleFields: true, fieldKeys: map[string]struct{}{
-						"key1": struct{}{},
-						"key2": struct{}{},
+					{k8sObject: cm1, singleFields: false, fieldKeys: map[string]ConfigField{}},
+					{k8sObject: cm2, singleFields: true, fieldKeys: map[string]ConfigField{
+						"key1": ConfigField{optional: false},
+						"key2": ConfigField{optional: false},
 					},
 					},
-					{k8sObject: s1, singleFields: false, fieldKeys: map[string]struct{}{}},
-					{k8sObject: s2, singleFields: false, fieldKeys: map[string]struct{}{}},
+					{k8sObject: s1, singleFields: false, fieldKeys: map[string]ConfigField{}},
+					{k8sObject: s2, singleFields: false, fieldKeys: map[string]ConfigField{}},
 				}
 				existing := []Object{cm1, s2}
 				Expect(getOrphans(existing, current)).To(BeEmpty())
@@ -298,10 +298,10 @@ var _ = Describe("Wave owner references Suite", func() {
 
 			It("returns the correct objects when current is a subset of existing", func() {
 				current := []ConfigObject{
-					{k8sObject: cm1, singleFields: false, fieldKeys: map[string]struct{}{}},
-					{k8sObject: s2, singleFields: true, fieldKeys: map[string]struct{}{
-						"key1": struct{}{},
-						"key2": struct{}{},
+					{k8sObject: cm1, singleFields: false, fieldKeys: map[string]ConfigField{}},
+					{k8sObject: s2, singleFields: true, fieldKeys: map[string]ConfigField{
+						"key1": ConfigField{optional: false},
+						"key2": ConfigField{optional: false},
 					},
 					},
 				}

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -43,10 +43,16 @@ type Object interface {
 	metav1.Object
 }
 
+// ConfigField is used to contain information about a specific field within
+// a ConfigMap/Secret to control how Wave uses that field.
+type ConfigField struct {
+	optional bool
+}
+
 // ConfigObject is used as a container of an "Object" along with metadata
-// that Wave uses to determine what to use from that Object
+// that Wave uses to determine what to use from that Object.
 type ConfigObject struct {
 	k8sObject    Object
 	singleFields bool
-	fieldKeys    map[string]struct{}
+	fieldKeys    map[string]ConfigField
 }

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Pusher Ltd.
+Copyright 2018, 2019 Pusher Ltd.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -41,4 +41,12 @@ const (
 type Object interface {
 	runtime.Object
 	metav1.Object
+}
+
+// ConfigObject is used as a container of an "Object" along with metadata
+// that Wave uses to determine what to use from that Object
+type ConfigObject struct {
+	k8sObject    Object
+	singleFields bool
+	fieldKeys    map[string]struct{}
 }

--- a/test/utils/test_objects.go
+++ b/test/utils/test_objects.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Pusher Ltd.
+Copyright 2018, 2019 Pusher Ltd.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -66,6 +66,63 @@ var ExampleDeployment = &appsv1.Deployment{
 					{
 						Name:  "container1",
 						Image: "container1",
+						Env: []corev1.EnvVar{
+							{
+								Name: "example3_key1",
+								ValueFrom: &corev1.EnvVarSource{
+									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "example3",
+										},
+										Key: "key1",
+									},
+								},
+							},
+							{
+								Name: "example1_key1",
+								ValueFrom: &corev1.EnvVarSource{
+									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "example1",
+										},
+										Key: "key1",
+									},
+								},
+							},
+							{
+								Name: "example1_key1_new_name",
+								ValueFrom: &corev1.EnvVarSource{
+									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "example1",
+										},
+										Key: "key1",
+									},
+								},
+							},
+							{
+								Name: "example3_secret_key1",
+								ValueFrom: &corev1.EnvVarSource{
+									SecretKeyRef: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "example3",
+										},
+										Key: "key1",
+									},
+								},
+							},
+							{
+								Name: "example1_secret_key1",
+								ValueFrom: &corev1.EnvVarSource{
+									SecretKeyRef: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "example1",
+										},
+										Key: "key1",
+									},
+								},
+							},
+						},
 						EnvFrom: []corev1.EnvFromSource{
 							{
 								ConfigMapRef: &corev1.ConfigMapEnvSource{
@@ -86,6 +143,30 @@ var ExampleDeployment = &appsv1.Deployment{
 					{
 						Name:  "container2",
 						Image: "container2",
+						Env: []corev1.EnvVar{
+							{
+								Name: "example3_key2",
+								ValueFrom: &corev1.EnvVarSource{
+									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "example3",
+										},
+										Key: "key2",
+									},
+								},
+							},
+							{
+								Name: "example3_secret_key2",
+								ValueFrom: &corev1.EnvVarSource{
+									SecretKeyRef: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "example3",
+										},
+										Key: "key2",
+									},
+								},
+							},
+						},
 						EnvFrom: []corev1.EnvFromSource{
 							{
 								ConfigMapRef: &corev1.ConfigMapEnvSource{
@@ -137,6 +218,20 @@ var ExampleConfigMap2 = &corev1.ConfigMap{
 	},
 }
 
+// ExampleConfigMap3 is an example ConfigMap object for use within test suites
+var ExampleConfigMap3 = &corev1.ConfigMap{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "example3",
+		Namespace: "default",
+		Labels:    labels,
+	},
+	Data: map[string]string{
+		"key1": "example3:key1",
+		"key2": "example3:key2",
+		"key3": "example3:key3",
+	},
+}
+
 // ExampleSecret1 is an example ConfigMap object for use within test suites
 var ExampleSecret1 = &corev1.Secret{
 	ObjectMeta: metav1.ObjectMeta{
@@ -162,5 +257,19 @@ var ExampleSecret2 = &corev1.Secret{
 		"key1": "example2:key1",
 		"key2": "example2:key2",
 		"key3": "example2:key3",
+	},
+}
+
+// ExampleSecret3 is an example ConfigMap object for use within test suites
+var ExampleSecret3 = &corev1.Secret{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "example3",
+		Namespace: "default",
+		Labels:    labels,
+	},
+	StringData: map[string]string{
+		"key1": "example3:key1",
+		"key2": "example3:key2",
+		"key3": "example3:key3",
 	},
 }

--- a/test/utils/test_objects.go
+++ b/test/utils/test_objects.go
@@ -26,6 +26,8 @@ var labels = map[string]string{
 	"app": "example",
 }
 
+var trueValue bool = true
+
 // ExampleDeployment is an example Deployment object for use within test suites
 var ExampleDeployment = &appsv1.Deployment{
 	ObjectMeta: metav1.ObjectMeta{
@@ -79,6 +81,18 @@ var ExampleDeployment = &appsv1.Deployment{
 								},
 							},
 							{
+								Name: "example3_key4",
+								ValueFrom: &corev1.EnvVarSource{
+									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "example3",
+										},
+										Key:      "key4",
+										Optional: &trueValue,
+									},
+								},
+							},
+							{
 								Name: "example1_key1",
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
@@ -108,6 +122,18 @@ var ExampleDeployment = &appsv1.Deployment{
 											Name: "example3",
 										},
 										Key: "key1",
+									},
+								},
+							},
+							{
+								Name: "example3_secret_key4",
+								ValueFrom: &corev1.EnvVarSource{
+									SecretKeyRef: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "example3",
+										},
+										Key:      "key4",
+										Optional: &trueValue,
 									},
 								},
 							},


### PR DESCRIPTION
Changes made:

- Added two new types:
  - ConfigObject: contains the k8s `Object`, a flag for whether this entry is only "single-field" env entries, and a list of referenced keys (map of key-name to a ConfigField)
  - ConfigField: contains metadata about that entry.  At the moment this is only a flag for whether that field is optional.
- When searching for "children"
  - Searching for children now looks in the `env` section, returning two new maps (one for ConfigMaps and one for Secrets), of maps (the second key being the key-name in the ConfigMap/Secret being accessed).  This code also handles the optional field (see below for more fun on optional).
  - Read in the data from the ConfigMaps/Secrets referenced in the env section.  Note that this _only_ looks at single-field entries if we don't already pull in the entire ConfigMap/Secret.  Given that requesting the ConfigMap/Secret is multi-threaded, I have passed in the metadata about being a single-field, and then passed it back in the "getResult" object.  I was also a bit paranoid in the algorithm for combining results so that also handles both single-field and entire-object results, merging such that the entire-object wins.  This did mean building up a _map_ of results, then converting to an array when done.
  - The "children" unit tests have been extended to catch as many new cases as I can think of.
  - I didn't change `handler.go` as the general flow hasn't changed, but I added some extra tests.  **Note** while adding tests, I think I found a bug.  There are several tests that check that the hash has changed, but the test code does this by checking that it does _not_ find the original hash in an annotation, and I think it currently looks in the wrong annotation (and as such, the test would never fail).  For example, https://github.com/pusher/wave/blob/master/pkg/core/handler_test.go#L229 calls `m.Eventually(deployment, timeout).ShouldNot(utils.WithAnnotations(HaveKeyWithValue(ConfigHashAnnotation, originalHash)))`, but I think it should call `m.Eventually(deployment, timeout).ShouldNot(utils.WithPodTemplateAnnotations(HaveKeyWithValue(ConfigHashAnnotation, originalHash)))`.  Please correct me if I've missed something!
  - The hashing code includes the new single-field data and includes only those fields in the hash it builds up.  Lots more tests added for the new behavour.

Testing done:

- New unit tests added and run
- Docker image built and tested in a minikube environment.
  - With an explicitly requested ConfigMap entry in the `env` section, only that pod is redeployed when only that value changes.
  - With an explicitly requested Secret entry in the `env` section, only that pod is redeployed when only that value changes.
  - With an optional entry in an existing ConfigMap, when that entry is referenced in the `env` section, only that pod is redeployed when that value is first added or when it changes.
  - With an optional entry in an existing Secret, when that entry is referenced in the `env` section, only that pod is redeployed when that value is first added or when it changes.
  - Existing behaviour for references using `volume` and `envFrom` is maintained: any change to referenced ConfigMaps/Secrets triggers a redeploy of only those pods that reference them.
  - An `env` section that contains two references to the same field in a ConfigMap/Secret but with different names successfully redeploys when that value changes (yep, we've got this in our system - two different squads with different names for the same configuration parameter!)

- I've not done any soak-testing or any heavy load testing so I hopefully haven't introduced any memory leaks.

What is not in this PR:

- I have not added anything that handles the `optional` flag on `envFrom`.  In that case, you can say whether the entire ConfigMap is allowed to be missing or not, but technically I was only working on the `env` section :)
- There is an edge case that I have not solved that relates to the `optional` flag on entries in the `env` section, partly because I'm not sure how.  Image that the following are all true:
  - I have an optional reference in an `env` section
  - It is the only reference to a particular ConfigMap/Secret in my deployment YAML
  - That entire ConfigMap/Secret does not exist

  In this case, when I deploy, we attempt to look up the field and get an error (e.g. `E0114 17:54:50.356820       1 :0] kubebuilder/controller "msg"="Reconciler error" "error"="error fetching current children: error(s) encountered when geting children: ConfigMap \"config-optional\" not found"  "Controller"="deployment-controller" "Request"={"Namespace":"default","Name":"charlie"}`.  But k8s thinks this is a valid deployment file, so honours the deployment and the pod starts up anyway, just without the missing config being defined.

  If I then create that ConfigMap, Wave takes some time to notice.  The problem is that it is relying on k8s backoff to "re-kick" the Wave handler after some timeout, at which point it successfully discovers the ConfigMap/Secret, and generates the hash.  Ideally, it would notice instantly, as with any other config change, but since the ConfigMap/Secret did not exist we never got to register "this" deployment as an owner.  Overal, it seems to work and "sort itself out in the end", but I'm just nervous about errors in the log but an apparently working system.