### PR TITLE
Typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ standby will be promoted to master.
 To enable leader election, set the following flags:
 
 ```
---leader-elect=true
+--leader-election=true
 --leader-election-id=<name-of-leader-election-configmap>
 --leader-election-namespace=<namespace-controller-runs-in>
 ```


### PR DESCRIPTION
Found a minor typo in the readme for the section on leader election.