### PR TITLE
Add DaemonSet support

### DIFF
--- a/config/rbac/manager_role.yaml
+++ b/config/rbac/manager_role.yaml
@@ -7,6 +7,44 @@ rules:
 - apiGroups:
   - apps
   resources:
+  - daemonsets
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - update
+  - patch
+- apiGroups:
+  - apps
+  resources:
   - deployments
   verbs:
   - get

--- a/pkg/controller/add_daemonset.go
+++ b/pkg/controller/add_daemonset.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2018 Pusher Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"github.com/pusher/wave/pkg/controller/daemonset"
+)
+
+func init() {
+	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
+	AddToManagerFuncs = append(AddToManagerFuncs, daemonset.Add)
+}

--- a/pkg/controller/daemonset/daemonset_controller.go
+++ b/pkg/controller/daemonset/daemonset_controller.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2018 Pusher Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package daemonset
+
+import (
+	"context"
+
+	"github.com/pusher/wave/pkg/core"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+// Add creates a new DaemonSet Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
+// and Start it when the Manager is Started.
+func Add(mgr manager.Manager) error {
+	return add(mgr, newReconciler(mgr))
+}
+
+// newReconciler returns a new reconcile.Reconciler
+func newReconciler(mgr manager.Manager) reconcile.Reconciler {
+	return &ReconcileDaemonSet{
+		scheme:  mgr.GetScheme(),
+		handler: core.NewHandler(mgr.GetClient(), mgr.GetEventRecorderFor("wave")),
+	}
+}
+
+// add adds a new Controller to mgr with r as the reconcile.Reconciler
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New("daemonset-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes to DaemonSet
+	err = c.Watch(&source.Kind{Type: &appsv1.DaemonSet{}}, &handler.EnqueueRequestForObject{})
+	if err != nil {
+		return err
+	}
+
+	// Watch ConfigMaps owned by a DaemonSet
+	err = c.Watch(&source.Kind{Type: &corev1.ConfigMap{}}, &handler.EnqueueRequestForOwner{
+		IsController: false,
+		OwnerType:    &appsv1.DaemonSet{},
+	})
+	if err != nil {
+		return err
+	}
+
+	// Watch Secrets owned by a DaemonSet
+	err = c.Watch(&source.Kind{Type: &corev1.Secret{}}, &handler.EnqueueRequestForOwner{
+		IsController: false,
+		OwnerType:    &appsv1.DaemonSet{},
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var _ reconcile.Reconciler = &ReconcileDaemonSet{}
+
+// ReconcileDaemonSet reconciles a DaemonSet object
+type ReconcileDaemonSet struct {
+	scheme  *runtime.Scheme
+	handler *core.Handler
+}
+
+// Reconcile reads that state of the cluster for a DaemonSet object and
+// updates its PodSpec based on mounted configuration
+// +kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=,resources=configmaps,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=,resources=secrets,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=,resources=events,verbs=create;update;patch
+func (r *ReconcileDaemonSet) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	// Fetch the DaemonSet instance
+	instance := &appsv1.DaemonSet{}
+	err := r.handler.Get(context.TODO(), request.NamespacedName, instance)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Object not found, return.  Created objects are automatically garbage collected.
+			return reconcile.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return reconcile.Result{}, err
+	}
+
+	return r.handler.HandleDaemonSet(instance)
+}

--- a/pkg/controller/daemonset/daemonset_controller_suite_test.go
+++ b/pkg/controller/daemonset/daemonset_controller_suite_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2018 Pusher Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package daemonset
+
+import (
+	"log"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/pusher/wave/test/reporters"
+
+	"github.com/go-logr/glogr"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pusher/wave/pkg/apis"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+var cfg *rest.Config
+
+func TestMain(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecsWithDefaultAndCustomReporters(t, "Wave Controller Suite", reporters.Reporters())
+}
+
+var t *envtest.Environment
+
+var _ = BeforeSuite(func() {
+	t = &envtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "crds")},
+	}
+	apis.AddToScheme(scheme.Scheme)
+
+	logf.SetLogger(glogr.New())
+
+	var err error
+	if cfg, err = t.Start(); err != nil {
+		log.Fatal(err)
+	}
+})
+
+var _ = AfterSuite(func() {
+	t.Stop()
+})
+
+// SetupTestReconcile returns a reconcile.Reconcile implementation that delegates to inner and
+// writes the request to requests after Reconcile is finished.
+func SetupTestReconcile(inner reconcile.Reconciler) (reconcile.Reconciler, chan reconcile.Request) {
+	requests := make(chan reconcile.Request)
+	fn := reconcile.Func(func(req reconcile.Request) (reconcile.Result, error) {
+		result, err := inner.Reconcile(req)
+		requests <- req
+		return result, err
+	})
+	return fn, requests
+}
+
+// StartTestManager adds recFn
+func StartTestManager(mgr manager.Manager) (chan struct{}, *sync.WaitGroup) {
+	stop := make(chan struct{})
+	wg := &sync.WaitGroup{}
+	go func() {
+		defer GinkgoRecover()
+		wg.Add(1)
+		Expect(mgr.Start(stop)).NotTo(HaveOccurred())
+		wg.Done()
+	}()
+	return stop, wg
+}

--- a/pkg/controller/daemonset/daemonset_controller_test.go
+++ b/pkg/controller/daemonset/daemonset_controller_test.go
@@ -1,0 +1,399 @@
+/*
+Copyright 2018 Pusher Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package daemonset
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pusher/wave/pkg/core"
+	"github.com/pusher/wave/test/utils"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var _ = Describe("DaemonSet controller Suite", func() {
+	var c client.Client
+	var m utils.Matcher
+
+	var daemonset *appsv1.DaemonSet
+	var requests <-chan reconcile.Request
+	var mgrStopped *sync.WaitGroup
+	var stopMgr chan struct{}
+
+	const timeout = time.Second * 5
+	const consistentlyTimeout = time.Second
+
+	var ownerRef metav1.OwnerReference
+	var cm1 *corev1.ConfigMap
+	var cm2 *corev1.ConfigMap
+	var cm3 *corev1.ConfigMap
+	var s1 *corev1.Secret
+	var s2 *corev1.Secret
+	var s3 *corev1.Secret
+
+	var waitForDaemonSetReconciled = func(obj core.Object) {
+		request := reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      obj.GetName(),
+				Namespace: obj.GetNamespace(),
+			},
+		}
+		// wait for reconcile for creating the DaemonSet
+		Eventually(requests, timeout).Should(Receive(Equal(request)))
+	}
+
+	BeforeEach(func() {
+		mgr, err := manager.New(cfg, manager.Options{})
+		Expect(err).NotTo(HaveOccurred())
+		c = mgr.GetClient()
+		m = utils.Matcher{Client: c}
+
+		var recFn reconcile.Reconciler
+		recFn, requests = SetupTestReconcile(newReconciler(mgr))
+		Expect(add(mgr, recFn)).NotTo(HaveOccurred())
+
+		stopMgr, mgrStopped = StartTestManager(mgr)
+
+		// Create some configmaps and secrets
+		cm1 = utils.ExampleConfigMap1.DeepCopy()
+		cm2 = utils.ExampleConfigMap2.DeepCopy()
+		cm3 = utils.ExampleConfigMap3.DeepCopy()
+		s1 = utils.ExampleSecret1.DeepCopy()
+		s2 = utils.ExampleSecret2.DeepCopy()
+		s3 = utils.ExampleSecret3.DeepCopy()
+
+		m.Create(cm1).Should(Succeed())
+		m.Create(cm2).Should(Succeed())
+		m.Create(cm3).Should(Succeed())
+		m.Create(s1).Should(Succeed())
+		m.Create(s2).Should(Succeed())
+		m.Create(s3).Should(Succeed())
+		m.Get(cm1, timeout).Should(Succeed())
+		m.Get(cm2, timeout).Should(Succeed())
+		m.Get(cm3, timeout).Should(Succeed())
+		m.Get(s1, timeout).Should(Succeed())
+		m.Get(s2, timeout).Should(Succeed())
+		m.Get(s3, timeout).Should(Succeed())
+
+		daemonset = utils.ExampleDaemonSet.DeepCopy()
+
+		// Create a daemonset and wait for it to be reconciled
+		m.Create(daemonset).Should(Succeed())
+		waitForDaemonSetReconciled(daemonset)
+
+		ownerRef = utils.GetOwnerRefDaemonSet(daemonset)
+	})
+
+	AfterEach(func() {
+		// Make sure to delete any finalizers (if the daemonset exists)
+		Eventually(func() error {
+			key := types.NamespacedName{Namespace: daemonset.GetNamespace(), Name: daemonset.GetName()}
+			err := c.Get(context.TODO(), key, daemonset)
+			if err != nil && errors.IsNotFound(err) {
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+			daemonset.SetFinalizers([]string{})
+			return c.Update(context.TODO(), daemonset)
+		}, timeout).Should(Succeed())
+
+		Eventually(func() error {
+			key := types.NamespacedName{Namespace: daemonset.GetNamespace(), Name: daemonset.GetName()}
+			err := c.Get(context.TODO(), key, daemonset)
+			if err != nil && errors.IsNotFound(err) {
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+			if len(daemonset.GetFinalizers()) > 0 {
+				return fmt.Errorf("Finalizers not upated")
+			}
+			return nil
+		}, timeout).Should(Succeed())
+
+		close(stopMgr)
+		mgrStopped.Wait()
+
+		utils.DeleteAll(cfg, timeout,
+			&appsv1.DaemonSetList{},
+			&corev1.ConfigMapList{},
+			&corev1.SecretList{},
+			&corev1.EventList{},
+		)
+	})
+
+	Context("When a DaemonSet is reconciled", func() {
+		Context("And it has the required annotation", func() {
+			BeforeEach(func() {
+				addAnnotation := func(obj utils.Object) utils.Object {
+					annotations := obj.GetAnnotations()
+					if annotations == nil {
+						annotations = make(map[string]string)
+					}
+					annotations[core.RequiredAnnotation] = "true"
+					obj.SetAnnotations(annotations)
+					return obj
+				}
+
+				m.UpdateWithFunc(daemonset, addAnnotation).Should(Succeed())
+				waitForDaemonSetReconciled(daemonset)
+
+				// Get the updated DaemonSet
+				m.Get(daemonset, timeout).Should(Succeed())
+			})
+
+			It("Adds OwnerReferences to all children", func() {
+				for _, obj := range []core.Object{cm1, cm2, cm3, s1, s2, s3} {
+					m.Eventually(obj, timeout).Should(utils.WithOwnerReferences(ContainElement(ownerRef)))
+				}
+			})
+
+			It("Adds a finalizer to the DaemonSet", func() {
+				m.Eventually(daemonset, timeout).Should(utils.WithFinalizers(ContainElement(core.FinalizerString)))
+			})
+
+			It("Adds a config hash to the Pod Template", func() {
+				m.Eventually(daemonset, timeout).Should(utils.WithPodTemplateAnnotations(HaveKey(core.ConfigHashAnnotation)))
+			})
+
+			It("Sends an event when updating the hash", func() {
+				m.Eventually(daemonset, timeout).Should(utils.WithPodTemplateAnnotations(HaveKey(core.ConfigHashAnnotation)))
+
+				events := &corev1.EventList{}
+				eventMessage := func(event *corev1.Event) string {
+					return event.Message
+				}
+
+				hashMessage := "Configuration hash updated to ebabf80ef45218b27078a41ca16b35a4f91cb5672f389e520ae9da6ee3df3b1c"
+				m.Eventually(events, timeout).Should(utils.WithItems(ContainElement(WithTransform(eventMessage, Equal(hashMessage)))))
+			})
+
+			Context("And a child is removed", func() {
+				var originalHash string
+				BeforeEach(func() {
+					m.Eventually(daemonset, timeout).Should(utils.WithPodTemplateAnnotations(HaveKey(core.ConfigHashAnnotation)))
+					originalHash = daemonset.Spec.Template.GetAnnotations()[core.ConfigHashAnnotation]
+
+					// Remove "container2" which references Secret example2 and ConfigMap
+					// example2
+					removeContainer2 := func(obj utils.Object) utils.Object {
+						ss, _ := obj.(*appsv1.DaemonSet)
+						containers := ss.Spec.Template.Spec.Containers
+						Expect(containers[0].Name).To(Equal("container1"))
+						ss.Spec.Template.Spec.Containers = []corev1.Container{containers[0]}
+						return ss
+					}
+
+					m.UpdateWithFunc(daemonset, removeContainer2).Should(Succeed())
+					waitForDaemonSetReconciled(daemonset)
+
+					// Get the updated DaemonSet
+					m.Get(daemonset, timeout).Should(Succeed())
+				})
+
+				It("Removes the OwnerReference from the orphaned ConfigMap", func() {
+					m.Eventually(cm2, timeout).ShouldNot(utils.WithOwnerReferences(ContainElement(ownerRef)))
+				})
+
+				It("Removes the OwnerReference from the orphaned Secret", func() {
+					m.Eventually(s2, timeout).ShouldNot(utils.WithOwnerReferences(ContainElement(ownerRef)))
+				})
+
+				It("Updates the config hash in the Pod Template", func() {
+					m.Eventually(daemonset, timeout).ShouldNot(utils.WithPodTemplateAnnotations(HaveKeyWithValue(core.ConfigHashAnnotation, originalHash)))
+				})
+			})
+
+			Context("And a child is updated", func() {
+				var originalHash string
+
+				BeforeEach(func() {
+					m.Eventually(daemonset, timeout).Should(utils.WithPodTemplateAnnotations(HaveKey(core.ConfigHashAnnotation)))
+					originalHash = daemonset.Spec.Template.GetAnnotations()[core.ConfigHashAnnotation]
+				})
+
+				Context("A ConfigMap volume is updated", func() {
+					BeforeEach(func() {
+						modifyCM := func(obj utils.Object) utils.Object {
+							cm, _ := obj.(*corev1.ConfigMap)
+							cm.Data["key1"] = "modified"
+							return cm
+						}
+						m.UpdateWithFunc(cm1, modifyCM).Should(Succeed())
+
+						waitForDaemonSetReconciled(daemonset)
+
+						// Get the updated DaemonSet
+						m.Get(daemonset, timeout).Should(Succeed())
+					})
+
+					It("Updates the config hash in the Pod Template", func() {
+						m.Eventually(daemonset, timeout).ShouldNot(utils.WithAnnotations(HaveKeyWithValue(core.ConfigHashAnnotation, originalHash)))
+					})
+				})
+
+				Context("A ConfigMap EnvSource is updated", func() {
+					BeforeEach(func() {
+						modifyCM := func(obj utils.Object) utils.Object {
+							cm, _ := obj.(*corev1.ConfigMap)
+							cm.Data["key1"] = "modified"
+							return cm
+						}
+						m.UpdateWithFunc(cm2, modifyCM).Should(Succeed())
+
+						waitForDaemonSetReconciled(daemonset)
+
+						// Get the updated DaemonSet
+						m.Get(daemonset, timeout).Should(Succeed())
+					})
+
+					It("Updates the config hash in the Pod Template", func() {
+						m.Eventually(daemonset, timeout).ShouldNot(utils.WithAnnotations(HaveKeyWithValue(core.ConfigHashAnnotation, originalHash)))
+					})
+				})
+
+				Context("A Secret volume is updated", func() {
+					BeforeEach(func() {
+						modifyS := func(obj utils.Object) utils.Object {
+							s, _ := obj.(*corev1.Secret)
+							if s.StringData == nil {
+								s.StringData = make(map[string]string)
+							}
+							s.StringData["key1"] = "modified"
+							return s
+						}
+						m.UpdateWithFunc(s1, modifyS).Should(Succeed())
+
+						waitForDaemonSetReconciled(daemonset)
+
+						// Get the updated DaemonSet
+						m.Get(daemonset, timeout).Should(Succeed())
+					})
+
+					It("Updates the config hash in the Pod Template", func() {
+						m.Eventually(daemonset, timeout).ShouldNot(utils.WithAnnotations(HaveKeyWithValue(core.ConfigHashAnnotation, originalHash)))
+					})
+				})
+
+				Context("A Secret EnvSource is updated", func() {
+					BeforeEach(func() {
+						modifyS := func(obj utils.Object) utils.Object {
+							s, _ := obj.(*corev1.Secret)
+							if s.StringData == nil {
+								s.StringData = make(map[string]string)
+							}
+							s.StringData["key1"] = "modified"
+							return s
+						}
+						m.UpdateWithFunc(s2, modifyS).Should(Succeed())
+
+						waitForDaemonSetReconciled(daemonset)
+
+						// Get the updated DaemonSet
+						m.Get(daemonset, timeout).Should(Succeed())
+					})
+
+					It("Updates the config hash in the Pod Template", func() {
+						m.Eventually(daemonset, timeout).ShouldNot(utils.WithAnnotations(HaveKeyWithValue(core.ConfigHashAnnotation, originalHash)))
+					})
+				})
+			})
+
+			Context("And the annotation is removed", func() {
+				BeforeEach(func() {
+					removeAnnotations := func(obj utils.Object) utils.Object {
+						obj.SetAnnotations(make(map[string]string))
+						return obj
+					}
+					m.UpdateWithFunc(daemonset, removeAnnotations).Should(Succeed())
+					waitForDaemonSetReconciled(daemonset)
+
+					m.Eventually(daemonset, timeout).ShouldNot(utils.WithAnnotations(HaveKey(core.RequiredAnnotation)))
+				})
+
+				It("Removes the OwnerReference from the all children", func() {
+					for _, obj := range []core.Object{cm1, cm2, s1, s2} {
+						m.Eventually(obj, timeout).ShouldNot(utils.WithOwnerReferences(ContainElement(ownerRef)))
+					}
+				})
+
+				It("Removes the DaemonSet's finalizer", func() {
+					m.Eventually(daemonset, timeout).ShouldNot(utils.WithFinalizers(ContainElement(core.FinalizerString)))
+				})
+			})
+
+			Context("And is deleted", func() {
+				BeforeEach(func() {
+					// Make sure the cache has synced before we run the test
+					m.Eventually(daemonset, timeout).Should(utils.WithPodTemplateAnnotations(HaveKey(core.ConfigHashAnnotation)))
+					m.Delete(daemonset).Should(Succeed())
+					m.Eventually(daemonset, timeout).ShouldNot(utils.WithDeletionTimestamp(BeNil()))
+					waitForDaemonSetReconciled(daemonset)
+
+					// Get the updated DaemonSet
+					m.Get(daemonset, timeout).Should(Succeed())
+				})
+				It("Removes the OwnerReference from the all children", func() {
+					for _, obj := range []core.Object{cm1, cm2, s1, s2} {
+						m.Eventually(obj, timeout).ShouldNot(utils.WithOwnerReferences(ContainElement(ownerRef)))
+					}
+				})
+
+				It("Removes the DaemonSet's finalizer", func() {
+					// Removing the finalizer causes the daemonset to be deleted
+					m.Get(daemonset, timeout).ShouldNot(Succeed())
+				})
+			})
+		})
+
+		Context("And it does not have the required annotation", func() {
+			BeforeEach(func() {
+				// Get the updated DaemonSet
+				m.Get(daemonset, timeout).Should(Succeed())
+			})
+
+			It("Doesn't add any OwnerReferences to any children", func() {
+				for _, obj := range []core.Object{cm1, cm2, s1, s2} {
+					m.Consistently(obj, consistentlyTimeout).ShouldNot(utils.WithOwnerReferences(ContainElement(ownerRef)))
+				}
+			})
+
+			It("Doesn't add a finalizer to the DaemonSet", func() {
+				m.Consistently(daemonset, consistentlyTimeout).ShouldNot(utils.WithFinalizers(ContainElement(core.FinalizerString)))
+			})
+
+			It("Doesn't add a config hash to the Pod Template", func() {
+				m.Consistently(daemonset, consistentlyTimeout).ShouldNot(utils.WithAnnotations(ContainElement(core.ConfigHashAnnotation)))
+			})
+		})
+	})
+
+})

--- a/pkg/core/handler.go
+++ b/pkg/core/handler.go
@@ -50,6 +50,11 @@ func (h *Handler) HandleStatefulSet(instance *appsv1.StatefulSet) (reconcile.Res
 	return h.handlePodController(&statefulset{StatefulSet: instance})
 }
 
+// HandleDaemonSet is called by the DaemonSet controller to reconcile DaemonSets
+func (h *Handler) HandleDaemonSet(instance *appsv1.DaemonSet) (reconcile.Result, error) {
+	return h.handlePodController(&daemonset{DaemonSet: instance})
+}
+
 // handlePodController reconciles the state of a podController
 func (h *Handler) handlePodController(instance podController) (reconcile.Result, error) {
 	log := logf.Log.WithName("wave")

--- a/pkg/core/owner_references.go
+++ b/pkg/core/owner_references.go
@@ -154,6 +154,8 @@ func kindOf(obj Object) string {
 		return "Deployment"
 	case *statefulset:
 		return "StatefulSet"
+	case *daemonset:
+		return "DaemonSet"
 	default:
 		return "Unknown"
 	}

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -106,3 +106,23 @@ func (d *statefulset) SetPodTemplate(template *corev1.PodTemplateSpec) {
 func (d *statefulset) DeepCopy() podController {
 	return &statefulset{d.StatefulSet.DeepCopy()}
 }
+
+type daemonset struct {
+	*appsv1.DaemonSet
+}
+
+func (d *daemonset) GetObject() runtime.Object {
+	return d.DaemonSet
+}
+
+func (d *daemonset) GetPodTemplate() *corev1.PodTemplateSpec {
+	return &d.DaemonSet.Spec.Template
+}
+
+func (d *daemonset) SetPodTemplate(template *corev1.PodTemplateSpec) {
+	d.DaemonSet.Spec.Template = *template
+}
+
+func (d *daemonset) DeepCopy() podController {
+	return &daemonset{d.DaemonSet.DeepCopy()}
+}

--- a/test/utils/matchers.go
+++ b/test/utils/matchers.go
@@ -196,6 +196,8 @@ func WithPodTemplateAnnotations(matcher gtypes.GomegaMatcher) gtypes.GomegaMatch
 			return obj.(*appsv1.Deployment).Spec.Template.GetAnnotations()
 		case *appsv1.StatefulSet:
 			return obj.(*appsv1.StatefulSet).Spec.Template.GetAnnotations()
+		case *appsv1.DaemonSet:
+			return obj.(*appsv1.DaemonSet).Spec.Template.GetAnnotations()
 		default:
 			panic("Unknown pod template type.")
 		}

--- a/test/utils/owner_ref.go
+++ b/test/utils/owner_ref.go
@@ -48,3 +48,17 @@ func GetOwnerRefStatefulSet(sts *appsv1.StatefulSet) metav1.OwnerReference {
 		BlockOwnerDeletion: &t,
 	}
 }
+
+// GetOwnerRefDaemonSet constructs an owner reference for the DaemonSet given
+func GetOwnerRefDaemonSet(sts *appsv1.DaemonSet) metav1.OwnerReference {
+	f := false
+	t := true
+	return metav1.OwnerReference{
+		APIVersion:         "apps/v1",
+		Kind:               "DaemonSet",
+		Name:               sts.Name,
+		UID:                sts.UID,
+		Controller:         &f,
+		BlockOwnerDeletion: &t,
+	}
+}

--- a/test/utils/test_objects.go
+++ b/test/utils/test_objects.go
@@ -452,6 +452,218 @@ var ExampleStatefulSet = &appsv1.StatefulSet{
 	},
 }
 
+// ExampleDaemonSet is an example DaemonSet object for use within test suites
+var ExampleDaemonSet = &appsv1.DaemonSet{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "example",
+		Namespace: "default",
+		Labels:    labels,
+	},
+	Spec: appsv1.DaemonSetSpec{
+		Selector: &metav1.LabelSelector{
+			MatchLabels: labels,
+		},
+		Template: corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: labels,
+			},
+			Spec: corev1.PodSpec{
+				Volumes: []corev1.Volume{
+					{
+						Name: "secret1",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								SecretName: "example1",
+							},
+						},
+					},
+					{
+						Name: "configmap1",
+						VolumeSource: corev1.VolumeSource{
+							ConfigMap: &corev1.ConfigMapVolumeSource{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "example1",
+								},
+							},
+						},
+					},
+				},
+				Containers: []corev1.Container{
+					{
+						Name:  "container1",
+						Image: "container1",
+						Env: []corev1.EnvVar{
+							{
+								Name: "example1_key1",
+								ValueFrom: &corev1.EnvVarSource{
+									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "example1",
+										},
+										Key: "key1",
+									},
+								},
+							},
+							{
+								Name: "example1_key1_new_name",
+								ValueFrom: &corev1.EnvVarSource{
+									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "example1",
+										},
+										Key: "key1",
+									},
+								},
+							},
+							{
+								Name: "example3_key1",
+								ValueFrom: &corev1.EnvVarSource{
+									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "example3",
+										},
+										Key: "key1",
+									},
+								},
+							},
+							{
+								Name: "example3_key4",
+								ValueFrom: &corev1.EnvVarSource{
+									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "example3",
+										},
+										Key:      "key4",
+										Optional: &trueValue,
+									},
+								},
+							},
+							{
+								Name: "example4_key1",
+								ValueFrom: &corev1.EnvVarSource{
+									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "example4",
+										},
+										Key:      "key1",
+										Optional: &trueValue,
+									},
+								},
+							},
+							{
+								Name: "example1_secret_key1",
+								ValueFrom: &corev1.EnvVarSource{
+									SecretKeyRef: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "example1",
+										},
+										Key: "key1",
+									},
+								},
+							},
+							{
+								Name: "example3_secret_key1",
+								ValueFrom: &corev1.EnvVarSource{
+									SecretKeyRef: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "example3",
+										},
+										Key: "key1",
+									},
+								},
+							},
+							{
+								Name: "example3_secret_key4",
+								ValueFrom: &corev1.EnvVarSource{
+									SecretKeyRef: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "example3",
+										},
+										Key:      "key4",
+										Optional: &trueValue,
+									},
+								},
+							},
+							{
+								Name: "example4_secret_key1",
+								ValueFrom: &corev1.EnvVarSource{
+									SecretKeyRef: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "example4",
+										},
+										Key:      "key1",
+										Optional: &trueValue,
+									},
+								},
+							},
+						},
+						EnvFrom: []corev1.EnvFromSource{
+							{
+								ConfigMapRef: &corev1.ConfigMapEnvSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "example1",
+									},
+								},
+							},
+							{
+								SecretRef: &corev1.SecretEnvSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "example1",
+									},
+								},
+							},
+						},
+					},
+					{
+						Name:  "container2",
+						Image: "container2",
+						Env: []corev1.EnvVar{
+							{
+								Name: "example3_key2",
+								ValueFrom: &corev1.EnvVarSource{
+									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "example3",
+										},
+										Key: "key2",
+									},
+								},
+							},
+							{
+								Name: "example3_secret_key2",
+								ValueFrom: &corev1.EnvVarSource{
+									SecretKeyRef: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "example3",
+										},
+										Key: "key2",
+									},
+								},
+							},
+						},
+						EnvFrom: []corev1.EnvFromSource{
+							{
+								ConfigMapRef: &corev1.ConfigMapEnvSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "example2",
+									},
+								},
+							},
+							{
+								SecretRef: &corev1.SecretEnvSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "example2",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
 // ExampleConfigMap1 is an example ConfigMap object for use within test suites
 var ExampleConfigMap1 = &corev1.ConfigMap{
 	ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Fixes #21.

Adds DaemonSet support to the Wave controller. Mirrors the work done for StatefulSets.

Effectively a copy paste with lots of search and replacing for the terms `StatefulSet` -> `DaemonSet` and `statefulset` -> `daemonset`