### PR TITLE
[IS-698] - Remove redundant Update matcher

### DIFF
--- a/pkg/controller/daemonset/daemonset_controller_test.go
+++ b/pkg/controller/daemonset/daemonset_controller_test.go
@@ -170,7 +170,7 @@ var _ = Describe("DaemonSet controller Suite", func() {
 					return obj
 				}
 
-				m.UpdateWithFunc(daemonset, addAnnotation).Should(Succeed())
+				m.Update(daemonset, addAnnotation).Should(Succeed())
 				waitForDaemonSetReconciled(daemonset)
 
 				// Get the updated DaemonSet
@@ -219,7 +219,7 @@ var _ = Describe("DaemonSet controller Suite", func() {
 						return ss
 					}
 
-					m.UpdateWithFunc(daemonset, removeContainer2).Should(Succeed())
+					m.Update(daemonset, removeContainer2).Should(Succeed())
 					waitForDaemonSetReconciled(daemonset)
 
 					// Get the updated DaemonSet
@@ -254,7 +254,7 @@ var _ = Describe("DaemonSet controller Suite", func() {
 							cm.Data["key1"] = modified
 							return cm
 						}
-						m.UpdateWithFunc(cm1, modifyCM).Should(Succeed())
+						m.Update(cm1, modifyCM).Should(Succeed())
 
 						waitForDaemonSetReconciled(daemonset)
 
@@ -274,7 +274,7 @@ var _ = Describe("DaemonSet controller Suite", func() {
 							cm.Data["key1"] = modified
 							return cm
 						}
-						m.UpdateWithFunc(cm2, modifyCM).Should(Succeed())
+						m.Update(cm2, modifyCM).Should(Succeed())
 
 						waitForDaemonSetReconciled(daemonset)
 
@@ -297,7 +297,7 @@ var _ = Describe("DaemonSet controller Suite", func() {
 							s.StringData["key1"] = modified
 							return s
 						}
-						m.UpdateWithFunc(s1, modifyS).Should(Succeed())
+						m.Update(s1, modifyS).Should(Succeed())
 
 						waitForDaemonSetReconciled(daemonset)
 
@@ -320,7 +320,7 @@ var _ = Describe("DaemonSet controller Suite", func() {
 							s.StringData["key1"] = modified
 							return s
 						}
-						m.UpdateWithFunc(s2, modifyS).Should(Succeed())
+						m.Update(s2, modifyS).Should(Succeed())
 
 						waitForDaemonSetReconciled(daemonset)
 
@@ -340,7 +340,7 @@ var _ = Describe("DaemonSet controller Suite", func() {
 						obj.SetAnnotations(make(map[string]string))
 						return obj
 					}
-					m.UpdateWithFunc(daemonset, removeAnnotations).Should(Succeed())
+					m.Update(daemonset, removeAnnotations).Should(Succeed())
 					waitForDaemonSetReconciled(daemonset)
 
 					m.Eventually(daemonset, timeout).ShouldNot(utils.WithAnnotations(HaveKey(core.RequiredAnnotation)))

--- a/pkg/controller/deployment/deployment_controller_test.go
+++ b/pkg/controller/deployment/deployment_controller_test.go
@@ -170,7 +170,7 @@ var _ = Describe("Deployment controller Suite", func() {
 					return obj
 				}
 
-				m.UpdateWithFunc(deployment, addAnnotation).Should(Succeed())
+				m.Update(deployment, addAnnotation).Should(Succeed())
 				waitForDeploymentReconciled(deployment)
 
 				// Get the updated Deployment
@@ -219,7 +219,7 @@ var _ = Describe("Deployment controller Suite", func() {
 						return dep
 					}
 
-					m.UpdateWithFunc(deployment, removeContainer2).Should(Succeed())
+					m.Update(deployment, removeContainer2).Should(Succeed())
 					waitForDeploymentReconciled(deployment)
 					waitForDeploymentReconciled(deployment)
 
@@ -255,7 +255,7 @@ var _ = Describe("Deployment controller Suite", func() {
 							cm.Data["key1"] = modified
 							return cm
 						}
-						m.UpdateWithFunc(cm1, modifyCM).Should(Succeed())
+						m.Update(cm1, modifyCM).Should(Succeed())
 
 						waitForDeploymentReconciled(deployment)
 
@@ -275,7 +275,7 @@ var _ = Describe("Deployment controller Suite", func() {
 							cm.Data["key1"] = modified
 							return cm
 						}
-						m.UpdateWithFunc(cm2, modifyCM).Should(Succeed())
+						m.Update(cm2, modifyCM).Should(Succeed())
 
 						waitForDeploymentReconciled(deployment)
 
@@ -298,7 +298,7 @@ var _ = Describe("Deployment controller Suite", func() {
 							s.StringData["key1"] = modified
 							return s
 						}
-						m.UpdateWithFunc(s1, modifyS).Should(Succeed())
+						m.Update(s1, modifyS).Should(Succeed())
 
 						waitForDeploymentReconciled(deployment)
 
@@ -321,7 +321,7 @@ var _ = Describe("Deployment controller Suite", func() {
 							s.StringData["key1"] = modified
 							return s
 						}
-						m.UpdateWithFunc(s2, modifyS).Should(Succeed())
+						m.Update(s2, modifyS).Should(Succeed())
 
 						waitForDeploymentReconciled(deployment)
 
@@ -341,7 +341,7 @@ var _ = Describe("Deployment controller Suite", func() {
 						obj.SetAnnotations(make(map[string]string))
 						return obj
 					}
-					m.UpdateWithFunc(deployment, removeAnnotations).Should(Succeed())
+					m.Update(deployment, removeAnnotations).Should(Succeed())
 					waitForDeploymentReconciled(deployment)
 
 					m.Eventually(deployment, timeout).ShouldNot(utils.WithAnnotations(HaveKey(core.RequiredAnnotation)))

--- a/pkg/controller/statefulset/statefulset_controller_test.go
+++ b/pkg/controller/statefulset/statefulset_controller_test.go
@@ -170,7 +170,7 @@ var _ = Describe("StatefulSet controller Suite", func() {
 					return obj
 				}
 
-				m.UpdateWithFunc(statefulset, addAnnotation).Should(Succeed())
+				m.Update(statefulset, addAnnotation).Should(Succeed())
 				waitForStatefulSetReconciled(statefulset)
 
 				// Get the updated StatefulSet
@@ -219,7 +219,7 @@ var _ = Describe("StatefulSet controller Suite", func() {
 						return ss
 					}
 
-					m.UpdateWithFunc(statefulset, removeContainer2).Should(Succeed())
+					m.Update(statefulset, removeContainer2).Should(Succeed())
 					waitForStatefulSetReconciled(statefulset)
 
 					// Get the updated StatefulSet
@@ -254,7 +254,7 @@ var _ = Describe("StatefulSet controller Suite", func() {
 							cm.Data["key1"] = modified
 							return cm
 						}
-						m.UpdateWithFunc(cm1, modifyCM).Should(Succeed())
+						m.Update(cm1, modifyCM).Should(Succeed())
 
 						waitForStatefulSetReconciled(statefulset)
 
@@ -274,7 +274,7 @@ var _ = Describe("StatefulSet controller Suite", func() {
 							cm.Data["key1"] = modified
 							return cm
 						}
-						m.UpdateWithFunc(cm2, modifyCM).Should(Succeed())
+						m.Update(cm2, modifyCM).Should(Succeed())
 
 						waitForStatefulSetReconciled(statefulset)
 
@@ -297,7 +297,7 @@ var _ = Describe("StatefulSet controller Suite", func() {
 							s.StringData["key1"] = modified
 							return s
 						}
-						m.UpdateWithFunc(s1, modifyS).Should(Succeed())
+						m.Update(s1, modifyS).Should(Succeed())
 
 						waitForStatefulSetReconciled(statefulset)
 
@@ -320,7 +320,7 @@ var _ = Describe("StatefulSet controller Suite", func() {
 							s.StringData["key1"] = modified
 							return s
 						}
-						m.UpdateWithFunc(s2, modifyS).Should(Succeed())
+						m.Update(s2, modifyS).Should(Succeed())
 
 						waitForStatefulSetReconciled(statefulset)
 
@@ -340,7 +340,7 @@ var _ = Describe("StatefulSet controller Suite", func() {
 						obj.SetAnnotations(make(map[string]string))
 						return obj
 					}
-					m.UpdateWithFunc(statefulset, removeAnnotations).Should(Succeed())
+					m.Update(statefulset, removeAnnotations).Should(Succeed())
 					waitForStatefulSetReconciled(statefulset)
 
 					m.Eventually(statefulset, timeout).ShouldNot(utils.WithAnnotations(HaveKey(core.RequiredAnnotation)))

--- a/pkg/core/children_test.go
+++ b/pkg/core/children_test.go
@@ -300,9 +300,10 @@ var _ = Describe("Wave children Suite", func() {
 			ownerRef := utils.GetOwnerRefDeployment(deploymentObject)
 
 			for _, obj := range []Object{cm1, s1} {
-				m.Get(obj, timeout).Should(Succeed())
-				obj.SetOwnerReferences([]metav1.OwnerReference{ownerRef})
-				m.Update(obj).Should(Succeed())
+				m.UpdateWithFunc(obj, func(obj utils.Object) utils.Object {
+					obj.SetOwnerReferences([]metav1.OwnerReference{ownerRef})
+					return obj
+				}, timeout).Should(Succeed())
 				m.Eventually(obj, timeout).Should(utils.WithOwnerReferences(ContainElement(ownerRef)))
 			}
 

--- a/pkg/core/children_test.go
+++ b/pkg/core/children_test.go
@@ -300,7 +300,7 @@ var _ = Describe("Wave children Suite", func() {
 			ownerRef := utils.GetOwnerRefDeployment(deploymentObject)
 
 			for _, obj := range []Object{cm1, s1} {
-				m.UpdateWithFunc(obj, func(obj utils.Object) utils.Object {
+				m.Update(obj, func(obj utils.Object) utils.Object {
 					obj.SetOwnerReferences([]metav1.OwnerReference{ownerRef})
 					return obj
 				}, timeout).Should(Succeed())

--- a/pkg/core/delete_test.go
+++ b/pkg/core/delete_test.go
@@ -95,7 +95,7 @@ var _ = Describe("Wave owner references Suite", func() {
 			s2 = utils.ExampleSecret2.DeepCopy()
 
 			for _, obj := range []Object{cm1, cm2, s1, s2} {
-				m.UpdateWithFunc(obj, func(obj utils.Object) utils.Object {
+				m.Update(obj, func(obj utils.Object) utils.Object {
 					obj.SetOwnerReferences([]metav1.OwnerReference{ownerRef})
 					return obj
 				}, timeout).Should(Succeed())
@@ -104,7 +104,7 @@ var _ = Describe("Wave owner references Suite", func() {
 			f := deploymentObject.GetFinalizers()
 			f = append(f, FinalizerString)
 			f = append(f, "keep.me.around/finalizer")
-			m.UpdateWithFunc(deploymentObject, func(obj utils.Object) utils.Object {
+			m.Update(deploymentObject, func(obj utils.Object) utils.Object {
 				obj.SetFinalizers(f)
 				return obj
 			}, timeout).Should(Succeed())

--- a/pkg/core/delete_test.go
+++ b/pkg/core/delete_test.go
@@ -95,15 +95,19 @@ var _ = Describe("Wave owner references Suite", func() {
 			s2 = utils.ExampleSecret2.DeepCopy()
 
 			for _, obj := range []Object{cm1, cm2, s1, s2} {
-				obj.SetOwnerReferences([]metav1.OwnerReference{ownerRef})
-				m.Update(obj).Should(Succeed())
+				m.UpdateWithFunc(obj, func(obj utils.Object) utils.Object {
+					obj.SetOwnerReferences([]metav1.OwnerReference{ownerRef})
+					return obj
+				}, timeout).Should(Succeed())
 			}
 
 			f := deploymentObject.GetFinalizers()
 			f = append(f, FinalizerString)
 			f = append(f, "keep.me.around/finalizer")
-			deploymentObject.SetFinalizers(f)
-			m.Update(deploymentObject).Should(Succeed())
+			m.UpdateWithFunc(deploymentObject, func(obj utils.Object) utils.Object {
+				obj.SetFinalizers(f)
+				return obj
+			}, timeout).Should(Succeed())
 
 			_, err := h.handleDelete(podControllerDeployment)
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/core/handler_test.go
+++ b/pkg/core/handler_test.go
@@ -147,7 +147,7 @@ var _ = Describe("Wave controller Suite", func() {
 				}
 				annotations[RequiredAnnotation] = requiredAnnotationValue
 
-				m.UpdateWithFunc(deployment, func(obj utils.Object) utils.Object {
+				m.Update(deployment, func(obj utils.Object) utils.Object {
 					obj.SetAnnotations(annotations)
 					return obj
 				}, timeout).Should(Succeed())
@@ -194,7 +194,7 @@ var _ = Describe("Wave controller Suite", func() {
 					// example2
 					containers := deployment.Spec.Template.Spec.Containers
 					Expect(containers[0].Name).To(Equal("container1"))
-					m.UpdateWithFunc(deployment, func(obj utils.Object) utils.Object {
+					m.Update(deployment, func(obj utils.Object) utils.Object {
 						dpl := obj.(*appsv1.Deployment)
 						dpl.Spec.Template.Spec.Containers = []corev1.Container{containers[0]}
 						return dpl
@@ -229,7 +229,7 @@ var _ = Describe("Wave controller Suite", func() {
 
 				Context("A ConfigMap volume is updated", func() {
 					BeforeEach(func() {
-						m.UpdateWithFunc(cm1, func(obj utils.Object) utils.Object {
+						m.Update(cm1, func(obj utils.Object) utils.Object {
 							cm := obj.(*corev1.ConfigMap)
 							cm.Data["key1"] = modified
 							return cm
@@ -249,7 +249,7 @@ var _ = Describe("Wave controller Suite", func() {
 
 				Context("A ConfigMap EnvSource is updated", func() {
 					BeforeEach(func() {
-						m.UpdateWithFunc(cm2, func(obj utils.Object) utils.Object {
+						m.Update(cm2, func(obj utils.Object) utils.Object {
 							cm := obj.(*corev1.ConfigMap)
 							cm.Data["key1"] = modified
 							return cm
@@ -269,7 +269,7 @@ var _ = Describe("Wave controller Suite", func() {
 
 				Context("A ConfigMap Env for a key being used is updated", func() {
 					BeforeEach(func() {
-						m.UpdateWithFunc(cm3, func(obj utils.Object) utils.Object {
+						m.Update(cm3, func(obj utils.Object) utils.Object {
 							cm := obj.(*corev1.ConfigMap)
 							cm.Data["key1"] = modified
 
@@ -290,7 +290,7 @@ var _ = Describe("Wave controller Suite", func() {
 
 				Context("A ConfigMap Env for a key that is not being used is updated", func() {
 					BeforeEach(func() {
-						m.UpdateWithFunc(cm3, func(obj utils.Object) utils.Object {
+						m.Update(cm3, func(obj utils.Object) utils.Object {
 							cm := obj.(*corev1.ConfigMap)
 							cm.Data["key3"] = modified
 
@@ -311,7 +311,7 @@ var _ = Describe("Wave controller Suite", func() {
 
 				Context("A Secret volume is updated", func() {
 					BeforeEach(func() {
-						m.UpdateWithFunc(s1, func(obj utils.Object) utils.Object {
+						m.Update(s1, func(obj utils.Object) utils.Object {
 							s := obj.(*corev1.Secret)
 							if s.StringData == nil {
 								s.StringData = make(map[string]string)
@@ -335,7 +335,7 @@ var _ = Describe("Wave controller Suite", func() {
 
 				Context("A Secret EnvSource is updated", func() {
 					BeforeEach(func() {
-						m.UpdateWithFunc(s2, func(obj utils.Object) utils.Object {
+						m.Update(s2, func(obj utils.Object) utils.Object {
 							s := obj.(*corev1.Secret)
 							if s.StringData == nil {
 								s.StringData = make(map[string]string)
@@ -359,7 +359,7 @@ var _ = Describe("Wave controller Suite", func() {
 
 				Context("A Secret Env for a key being used is updated", func() {
 					BeforeEach(func() {
-						m.UpdateWithFunc(s3, func(obj utils.Object) utils.Object {
+						m.Update(s3, func(obj utils.Object) utils.Object {
 							s := obj.(*corev1.Secret)
 							if s.StringData == nil {
 								s.StringData = make(map[string]string)
@@ -383,7 +383,7 @@ var _ = Describe("Wave controller Suite", func() {
 
 				Context("A Secret Env for a key that is not being used is updated", func() {
 					BeforeEach(func() {
-						m.UpdateWithFunc(s3, func(obj utils.Object) utils.Object {
+						m.Update(s3, func(obj utils.Object) utils.Object {
 							s := obj.(*corev1.Secret)
 							if s.StringData == nil {
 								s.StringData = make(map[string]string)
@@ -410,7 +410,7 @@ var _ = Describe("Wave controller Suite", func() {
 				BeforeEach(func() {
 					// Make sure the cache has synced before we run the test
 					m.Eventually(deployment, timeout).Should(utils.WithPodTemplateAnnotations(HaveKey(ConfigHashAnnotation)))
-					m.UpdateWithFunc(deployment, func(obj utils.Object) utils.Object {
+					m.Update(deployment, func(obj utils.Object) utils.Object {
 						obj.SetAnnotations(make(map[string]string))
 
 						return obj

--- a/pkg/core/handler_test.go
+++ b/pkg/core/handler_test.go
@@ -146,9 +146,11 @@ var _ = Describe("Wave controller Suite", func() {
 					annotations = make(map[string]string)
 				}
 				annotations[RequiredAnnotation] = requiredAnnotationValue
-				deployment.SetAnnotations(annotations)
 
-				m.Update(deployment).Should(Succeed())
+				m.UpdateWithFunc(deployment, func(obj utils.Object) utils.Object {
+					obj.SetAnnotations(annotations)
+					return obj
+				}, timeout).Should(Succeed())
 				_, err := h.HandleDeployment(deployment)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -192,8 +194,11 @@ var _ = Describe("Wave controller Suite", func() {
 					// example2
 					containers := deployment.Spec.Template.Spec.Containers
 					Expect(containers[0].Name).To(Equal("container1"))
-					deployment.Spec.Template.Spec.Containers = []corev1.Container{containers[0]}
-					m.Update(deployment).Should(Succeed())
+					m.UpdateWithFunc(deployment, func(obj utils.Object) utils.Object {
+						dpl := obj.(*appsv1.Deployment)
+						dpl.Spec.Template.Spec.Containers = []corev1.Container{containers[0]}
+						return dpl
+					}).Should(Succeed())
 					_, err := h.HandleDeployment(deployment)
 					Expect(err).NotTo(HaveOccurred())
 
@@ -224,9 +229,11 @@ var _ = Describe("Wave controller Suite", func() {
 
 				Context("A ConfigMap volume is updated", func() {
 					BeforeEach(func() {
-						m.Get(cm1, timeout).Should(Succeed())
-						cm1.Data["key1"] = modified
-						m.Update(cm1).Should(Succeed())
+						m.UpdateWithFunc(cm1, func(obj utils.Object) utils.Object {
+							cm := obj.(*corev1.ConfigMap)
+							cm.Data["key1"] = modified
+							return cm
+						}).Should(Succeed())
 
 						_, err := h.HandleDeployment(deployment)
 						Expect(err).NotTo(HaveOccurred())
@@ -242,9 +249,11 @@ var _ = Describe("Wave controller Suite", func() {
 
 				Context("A ConfigMap EnvSource is updated", func() {
 					BeforeEach(func() {
-						m.Get(cm2, timeout).Should(Succeed())
-						cm2.Data["key1"] = modified
-						m.Update(cm2).Should(Succeed())
+						m.UpdateWithFunc(cm2, func(obj utils.Object) utils.Object {
+							cm := obj.(*corev1.ConfigMap)
+							cm.Data["key1"] = modified
+							return cm
+						}, timeout).Should(Succeed())
 
 						_, err := h.HandleDeployment(deployment)
 						Expect(err).NotTo(HaveOccurred())
@@ -260,9 +269,12 @@ var _ = Describe("Wave controller Suite", func() {
 
 				Context("A ConfigMap Env for a key being used is updated", func() {
 					BeforeEach(func() {
-						m.Get(cm3, timeout).Should(Succeed())
-						cm3.Data["key1"] = modified
-						m.Update(cm3).Should(Succeed())
+						m.UpdateWithFunc(cm3, func(obj utils.Object) utils.Object {
+							cm := obj.(*corev1.ConfigMap)
+							cm.Data["key1"] = modified
+
+							return cm
+						}, timeout).Should(Succeed())
 
 						_, err := h.HandleDeployment(deployment)
 						Expect(err).NotTo(HaveOccurred())
@@ -278,9 +290,12 @@ var _ = Describe("Wave controller Suite", func() {
 
 				Context("A ConfigMap Env for a key that is not being used is updated", func() {
 					BeforeEach(func() {
-						m.Get(cm3, timeout).Should(Succeed())
-						cm3.Data["key3"] = modified
-						m.Update(cm3).Should(Succeed())
+						m.UpdateWithFunc(cm3, func(obj utils.Object) utils.Object {
+							cm := obj.(*corev1.ConfigMap)
+							cm.Data["key3"] = modified
+
+							return cm
+						}, timeout).Should(Succeed())
 
 						_, err := h.HandleDeployment(deployment)
 						Expect(err).NotTo(HaveOccurred())
@@ -296,12 +311,15 @@ var _ = Describe("Wave controller Suite", func() {
 
 				Context("A Secret volume is updated", func() {
 					BeforeEach(func() {
-						m.Get(s1, timeout).Should(Succeed())
-						if s1.StringData == nil {
-							s1.StringData = make(map[string]string)
-						}
-						s1.StringData["key1"] = modified
-						m.Update(s1).Should(Succeed())
+						m.UpdateWithFunc(s1, func(obj utils.Object) utils.Object {
+							s := obj.(*corev1.Secret)
+							if s.StringData == nil {
+								s.StringData = make(map[string]string)
+							}
+							s.StringData["key1"] = modified
+
+							return s
+						}, timeout).Should(Succeed())
 
 						_, err := h.HandleDeployment(deployment)
 						Expect(err).NotTo(HaveOccurred())
@@ -317,12 +335,15 @@ var _ = Describe("Wave controller Suite", func() {
 
 				Context("A Secret EnvSource is updated", func() {
 					BeforeEach(func() {
-						m.Get(s2, timeout).Should(Succeed())
-						if s2.StringData == nil {
-							s2.StringData = make(map[string]string)
-						}
-						s2.StringData["key1"] = modified
-						m.Update(s2).Should(Succeed())
+						m.UpdateWithFunc(s2, func(obj utils.Object) utils.Object {
+							s := obj.(*corev1.Secret)
+							if s.StringData == nil {
+								s.StringData = make(map[string]string)
+							}
+							s.StringData["key1"] = modified
+
+							return s
+						}, timeout).Should(Succeed())
 
 						_, err := h.HandleDeployment(deployment)
 						Expect(err).NotTo(HaveOccurred())
@@ -338,12 +359,15 @@ var _ = Describe("Wave controller Suite", func() {
 
 				Context("A Secret Env for a key being used is updated", func() {
 					BeforeEach(func() {
-						m.Get(s3, timeout).Should(Succeed())
-						if s3.StringData == nil {
-							s3.StringData = make(map[string]string)
-						}
-						s3.StringData["key1"] = modified
-						m.Update(s3).Should(Succeed())
+						m.UpdateWithFunc(s3, func(obj utils.Object) utils.Object {
+							s := obj.(*corev1.Secret)
+							if s.StringData == nil {
+								s.StringData = make(map[string]string)
+							}
+							s.StringData["key1"] = modified
+
+							return s
+						}, timeout).Should(Succeed())
 
 						_, err := h.HandleDeployment(deployment)
 						Expect(err).NotTo(HaveOccurred())
@@ -359,12 +383,15 @@ var _ = Describe("Wave controller Suite", func() {
 
 				Context("A Secret Env for a key that is not being used is updated", func() {
 					BeforeEach(func() {
-						m.Get(s3, timeout).Should(Succeed())
-						if s3.StringData == nil {
-							s3.StringData = make(map[string]string)
-						}
-						s3.StringData["key3"] = modified
-						m.Update(s3).Should(Succeed())
+						m.UpdateWithFunc(s3, func(obj utils.Object) utils.Object {
+							s := obj.(*corev1.Secret)
+							if s.StringData == nil {
+								s.StringData = make(map[string]string)
+							}
+							s.StringData["key3"] = modified
+
+							return s
+						}, timeout).Should(Succeed())
 
 						_, err := h.HandleDeployment(deployment)
 						Expect(err).NotTo(HaveOccurred())
@@ -383,10 +410,11 @@ var _ = Describe("Wave controller Suite", func() {
 				BeforeEach(func() {
 					// Make sure the cache has synced before we run the test
 					m.Eventually(deployment, timeout).Should(utils.WithPodTemplateAnnotations(HaveKey(ConfigHashAnnotation)))
+					m.UpdateWithFunc(deployment, func(obj utils.Object) utils.Object {
+						obj.SetAnnotations(make(map[string]string))
 
-					m.Get(deployment, timeout).Should(Succeed())
-					deployment.SetAnnotations(make(map[string]string))
-					m.Update(deployment).Should(Succeed())
+						return obj
+					}, timeout).Should(Succeed())
 					_, err := h.HandleDeployment(deployment)
 					Expect(err).NotTo(HaveOccurred())
 

--- a/pkg/core/hash_test.go
+++ b/pkg/core/hash_test.go
@@ -100,7 +100,7 @@ var _ = Describe("Wave hash Suite", func() {
 			h1, err := calculateConfigHash(c)
 			Expect(err).NotTo(HaveOccurred())
 
-			m.UpdateWithFunc(cm1, func(obj utils.Object) utils.Object {
+			m.Update(cm1, func(obj utils.Object) utils.Object {
 				cm := obj.(*corev1.ConfigMap)
 				cm.Data["key1"] = modified
 
@@ -123,7 +123,7 @@ var _ = Describe("Wave hash Suite", func() {
 			h1, err := calculateConfigHash(c)
 			Expect(err).NotTo(HaveOccurred())
 
-			m.UpdateWithFunc(cm1, func(obj utils.Object) utils.Object {
+			m.Update(cm1, func(obj utils.Object) utils.Object {
 				cm := obj.(*corev1.ConfigMap)
 				cm.Data["key1"] = modified
 
@@ -152,14 +152,14 @@ var _ = Describe("Wave hash Suite", func() {
 			h1, err := calculateConfigHash(c)
 			Expect(err).NotTo(HaveOccurred())
 
-			m.UpdateWithFunc(cm1, func(obj utils.Object) utils.Object {
+			m.Update(cm1, func(obj utils.Object) utils.Object {
 				cm := obj.(*corev1.ConfigMap)
 				cm.Data["key1"] = modified
 
 				return cm
 			}, timeout).Should(Succeed())
 
-			m.UpdateWithFunc(s1, func(obj utils.Object) utils.Object {
+			m.Update(s1, func(obj utils.Object) utils.Object {
 				s := obj.(*corev1.Secret)
 				s.Data["key1"] = []byte("modified")
 
@@ -188,14 +188,14 @@ var _ = Describe("Wave hash Suite", func() {
 			h1, err := calculateConfigHash(c)
 			Expect(err).NotTo(HaveOccurred())
 
-			m.UpdateWithFunc(cm1, func(obj utils.Object) utils.Object {
+			m.Update(cm1, func(obj utils.Object) utils.Object {
 				cm := obj.(*corev1.ConfigMap)
 				cm.Data["key3"] = modified
 
 				return cm
 			}, timeout).Should(Succeed())
 
-			m.UpdateWithFunc(s1, func(obj utils.Object) utils.Object {
+			m.Update(s1, func(obj utils.Object) utils.Object {
 				s1 := obj.(*corev1.Secret)
 				s1.Data["key3"] = []byte("modified")
 
@@ -218,7 +218,7 @@ var _ = Describe("Wave hash Suite", func() {
 			h1, err := calculateConfigHash(c)
 			Expect(err).NotTo(HaveOccurred())
 
-			m.UpdateWithFunc(s1, func(obj utils.Object) utils.Object {
+			m.Update(s1, func(obj utils.Object) utils.Object {
 				s := obj.(*corev1.Secret)
 				s.Annotations = map[string]string{"new": "annotations"}
 

--- a/pkg/core/hash_test.go
+++ b/pkg/core/hash_test.go
@@ -100,8 +100,12 @@ var _ = Describe("Wave hash Suite", func() {
 			h1, err := calculateConfigHash(c)
 			Expect(err).NotTo(HaveOccurred())
 
-			cm1.Data["key1"] = modified
-			m.Update(cm1).Should(Succeed())
+			m.UpdateWithFunc(cm1, func(obj utils.Object) utils.Object {
+				cm := obj.(*corev1.ConfigMap)
+				cm.Data["key1"] = modified
+
+				return cm
+			}, timeout).Should(Succeed())
 			h2, err := calculateConfigHash(c)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -119,8 +123,12 @@ var _ = Describe("Wave hash Suite", func() {
 			h1, err := calculateConfigHash(c)
 			Expect(err).NotTo(HaveOccurred())
 
-			cm1.Data["key1"] = modified
-			m.Update(cm1).Should(Succeed())
+			m.UpdateWithFunc(cm1, func(obj utils.Object) utils.Object {
+				cm := obj.(*corev1.ConfigMap)
+				cm.Data["key1"] = modified
+
+				return cm
+			}, timeout).Should(Succeed())
 			h2, err := calculateConfigHash(c)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -144,10 +152,19 @@ var _ = Describe("Wave hash Suite", func() {
 			h1, err := calculateConfigHash(c)
 			Expect(err).NotTo(HaveOccurred())
 
-			cm1.Data["key1"] = modified
-			m.Update(cm1).Should(Succeed())
-			s1.Data["key1"] = []byte("modified")
-			m.Update(s1).Should(Succeed())
+			m.UpdateWithFunc(cm1, func(obj utils.Object) utils.Object {
+				cm := obj.(*corev1.ConfigMap)
+				cm.Data["key1"] = modified
+
+				return cm
+			}, timeout).Should(Succeed())
+
+			m.UpdateWithFunc(s1, func(obj utils.Object) utils.Object {
+				s := obj.(*corev1.Secret)
+				s.Data["key1"] = []byte("modified")
+
+				return s
+			}, timeout).Should(Succeed())
 			h2, err := calculateConfigHash(c)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -171,10 +188,19 @@ var _ = Describe("Wave hash Suite", func() {
 			h1, err := calculateConfigHash(c)
 			Expect(err).NotTo(HaveOccurred())
 
-			cm1.Data["key3"] = modified
-			m.Update(cm1).Should(Succeed())
-			s1.Data["key3"] = []byte("modified")
-			m.Update(s1).Should(Succeed())
+			m.UpdateWithFunc(cm1, func(obj utils.Object) utils.Object {
+				cm := obj.(*corev1.ConfigMap)
+				cm.Data["key3"] = modified
+
+				return cm
+			}, timeout).Should(Succeed())
+
+			m.UpdateWithFunc(s1, func(obj utils.Object) utils.Object {
+				s1 := obj.(*corev1.Secret)
+				s1.Data["key3"] = []byte("modified")
+
+				return s1
+			}, timeout).Should(Succeed())
 			h2, err := calculateConfigHash(c)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -192,8 +218,12 @@ var _ = Describe("Wave hash Suite", func() {
 			h1, err := calculateConfigHash(c)
 			Expect(err).NotTo(HaveOccurred())
 
-			s1.Annotations = map[string]string{"new": "annotations"}
-			m.Update(s1).Should(Succeed())
+			m.UpdateWithFunc(s1, func(obj utils.Object) utils.Object {
+				s := obj.(*corev1.Secret)
+				s.Annotations = map[string]string{"new": "annotations"}
+
+				return s
+			}, timeout).Should(Succeed())
 			h2, err := calculateConfigHash(c)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/pkg/core/owner_references_test.go
+++ b/pkg/core/owner_references_test.go
@@ -102,8 +102,10 @@ var _ = Describe("Wave owner references Suite", func() {
 			for _, obj := range []Object{cm1, cm2, s1, s2} {
 				otherRef := ownerRef.DeepCopy()
 				otherRef.UID = obj.GetUID()
-				obj.SetOwnerReferences([]metav1.OwnerReference{ownerRef, *otherRef})
-				m.Update(obj).Should(Succeed())
+				m.UpdateWithFunc(obj, func(obj utils.Object) utils.Object {
+					obj.SetOwnerReferences([]metav1.OwnerReference{ownerRef, *otherRef})
+					return obj
+				}, timeout).Should(Succeed())
 
 				m.Eventually(obj, timeout).Should(utils.WithOwnerReferences(ConsistOf(ownerRef, *otherRef)))
 			}
@@ -146,9 +148,10 @@ var _ = Describe("Wave owner references Suite", func() {
 	Context("updateOwnerReferences", func() {
 		BeforeEach(func() {
 			for _, obj := range []Object{cm2, s1, s2} {
-				obj.SetOwnerReferences([]metav1.OwnerReference{ownerRef})
-				m.Update(obj).Should(Succeed())
-
+				m.UpdateWithFunc(obj, func(obj utils.Object) utils.Object {
+					obj.SetOwnerReferences([]metav1.OwnerReference{ownerRef})
+					return obj
+				}, timeout).Should(Succeed())
 				m.Eventually(obj, timeout).Should(utils.WithOwnerReferences(ContainElement(ownerRef)))
 			}
 
@@ -182,8 +185,12 @@ var _ = Describe("Wave owner references Suite", func() {
 	Context("updateOwnerReference", func() {
 		BeforeEach(func() {
 			// Add an OwnerReference to cm2
-			cm2.SetOwnerReferences([]metav1.OwnerReference{ownerRef})
-			m.Update(cm2).Should(Succeed())
+			m.UpdateWithFunc(cm2, func(obj utils.Object) utils.Object {
+				cm2 := obj.(*corev1.ConfigMap)
+				cm2.SetOwnerReferences([]metav1.OwnerReference{ownerRef})
+
+				return cm2
+			}, timeout).Should(Succeed())
 			m.Eventually(cm2, timeout).Should(utils.WithOwnerReferences(ContainElement(ownerRef)))
 
 			m.Get(cm1, timeout).Should(Succeed())
@@ -194,8 +201,12 @@ var _ = Describe("Wave owner references Suite", func() {
 			// Add an OwnerReference to cm1
 			otherRef := ownerRef
 			otherRef.UID = cm1.GetUID()
-			cm1.SetOwnerReferences([]metav1.OwnerReference{otherRef})
-			m.Update(cm1).Should(Succeed())
+			m.UpdateWithFunc(cm1, func(obj utils.Object) utils.Object {
+				cm1 := obj.(*corev1.ConfigMap)
+				cm1.SetOwnerReferences([]metav1.OwnerReference{otherRef})
+
+				return cm1
+			}, timeout).Should(Succeed())
 			m.Eventually(cm1, timeout).Should(utils.WithOwnerReferences(ContainElement(otherRef)))
 
 			m.Get(cm1, timeout).Should(Succeed())
@@ -205,8 +216,12 @@ var _ = Describe("Wave owner references Suite", func() {
 
 		It("doesn't update the child object if there is already and OwnerReference present", func() {
 			// Add an OwnerReference to cm2
-			cm2.SetOwnerReferences([]metav1.OwnerReference{ownerRef})
-			m.Update(cm2).Should(Succeed())
+			m.UpdateWithFunc(cm2, func(obj utils.Object) utils.Object {
+				cm2 := obj.(*corev1.ConfigMap)
+				cm2.SetOwnerReferences([]metav1.OwnerReference{ownerRef})
+
+				return cm2
+			}, timeout).Should(Succeed())
 			m.Eventually(cm2, timeout).Should(utils.WithOwnerReferences(ContainElement(ownerRef)))
 
 			// Get the original version

--- a/pkg/core/owner_references_test.go
+++ b/pkg/core/owner_references_test.go
@@ -102,7 +102,7 @@ var _ = Describe("Wave owner references Suite", func() {
 			for _, obj := range []Object{cm1, cm2, s1, s2} {
 				otherRef := ownerRef.DeepCopy()
 				otherRef.UID = obj.GetUID()
-				m.UpdateWithFunc(obj, func(obj utils.Object) utils.Object {
+				m.Update(obj, func(obj utils.Object) utils.Object {
 					obj.SetOwnerReferences([]metav1.OwnerReference{ownerRef, *otherRef})
 					return obj
 				}, timeout).Should(Succeed())
@@ -148,7 +148,7 @@ var _ = Describe("Wave owner references Suite", func() {
 	Context("updateOwnerReferences", func() {
 		BeforeEach(func() {
 			for _, obj := range []Object{cm2, s1, s2} {
-				m.UpdateWithFunc(obj, func(obj utils.Object) utils.Object {
+				m.Update(obj, func(obj utils.Object) utils.Object {
 					obj.SetOwnerReferences([]metav1.OwnerReference{ownerRef})
 					return obj
 				}, timeout).Should(Succeed())
@@ -185,7 +185,7 @@ var _ = Describe("Wave owner references Suite", func() {
 	Context("updateOwnerReference", func() {
 		BeforeEach(func() {
 			// Add an OwnerReference to cm2
-			m.UpdateWithFunc(cm2, func(obj utils.Object) utils.Object {
+			m.Update(cm2, func(obj utils.Object) utils.Object {
 				cm2 := obj.(*corev1.ConfigMap)
 				cm2.SetOwnerReferences([]metav1.OwnerReference{ownerRef})
 
@@ -201,7 +201,7 @@ var _ = Describe("Wave owner references Suite", func() {
 			// Add an OwnerReference to cm1
 			otherRef := ownerRef
 			otherRef.UID = cm1.GetUID()
-			m.UpdateWithFunc(cm1, func(obj utils.Object) utils.Object {
+			m.Update(cm1, func(obj utils.Object) utils.Object {
 				cm1 := obj.(*corev1.ConfigMap)
 				cm1.SetOwnerReferences([]metav1.OwnerReference{otherRef})
 
@@ -216,7 +216,7 @@ var _ = Describe("Wave owner references Suite", func() {
 
 		It("doesn't update the child object if there is already and OwnerReference present", func() {
 			// Add an OwnerReference to cm2
-			m.UpdateWithFunc(cm2, func(obj utils.Object) utils.Object {
+			m.Update(cm2, func(obj utils.Object) utils.Object {
 				cm2 := obj.(*corev1.ConfigMap)
 				cm2.SetOwnerReferences([]metav1.OwnerReference{ownerRef})
 

--- a/test/utils/matchers.go
+++ b/test/utils/matchers.go
@@ -57,14 +57,6 @@ func (m *Matcher) Delete(obj Object, extras ...interface{}) gomega.GomegaAsserti
 	return gomega.Expect(err, extras)
 }
 
-// Update udpates the object on the API server
-func (m *Matcher) Update(obj Object, intervals ...interface{}) gomega.GomegaAsyncAssertion {
-	update := func() error {
-		return m.Client.Update(context.TODO(), obj)
-	}
-	return gomega.Eventually(update, intervals...)
-}
-
 // UpdateWithFunc udpates the object on the API server by fetching the object
 // and applying a mutating UpdateFunc before sending the update
 func (m *Matcher) UpdateWithFunc(obj Object, fn UpdateFunc, intervals ...interface{}) gomega.GomegaAsyncAssertion {

--- a/test/utils/matchers.go
+++ b/test/utils/matchers.go
@@ -57,9 +57,9 @@ func (m *Matcher) Delete(obj Object, extras ...interface{}) gomega.GomegaAsserti
 	return gomega.Expect(err, extras)
 }
 
-// UpdateWithFunc udpates the object on the API server by fetching the object
+// Update udpates the object on the API server by fetching the object
 // and applying a mutating UpdateFunc before sending the update
-func (m *Matcher) UpdateWithFunc(obj Object, fn UpdateFunc, intervals ...interface{}) gomega.GomegaAsyncAssertion {
+func (m *Matcher) Update(obj Object, fn UpdateFunc, intervals ...interface{}) gomega.GomegaAsyncAssertion {
 	key := types.NamespacedName{
 		Name:      obj.GetName(),
 		Namespace: obj.GetNamespace(),


### PR DESCRIPTION
We replaced this `Update` matcher with the functional `UpdateWithFunc` matcher in some places and should therefore replace it everywhere and remove the (fundamentally) broken `Update` matcher.