### PR TITLE
Fix RBAC role examples to include DaemonSets and StatefulSets

### DIFF
--- a/config/default/manager/manager.yaml
+++ b/config/default/manager/manager.yaml
@@ -42,7 +42,7 @@ spec:
     spec:
       containers:
       - command:
-        - /bin/manager
+        - /bin/wave
         image: controller:latest
         imagePullPolicy: Always
         name: manager

--- a/config/default/manager/manager.yaml
+++ b/config/default/manager/manager.yaml
@@ -41,8 +41,6 @@ spec:
         controller-tools.k8s.io: "1.0"
     spec:
       containers:
-      - command:
-        - /bin/wave
         image: controller:latest
         imagePullPolicy: Always
         name: manager

--- a/config/default/rbac/rbac_role.yaml
+++ b/config/default/rbac/rbac_role.yaml
@@ -7,7 +7,9 @@ rules:
 - apiGroups:
   - apps
   resources:
+  - daemonsets
   - deployments
+  - statefulsets
   verbs:
   - get
   - list

--- a/config/rbac/manager_role.yaml
+++ b/config/rbac/manager_role.yaml
@@ -8,6 +8,8 @@ rules:
   - apps
   resources:
   - daemonsets
+  - deployments
+  - statefulsets
   verbs:
   - get
   - list


### PR DESCRIPTION
- manager RBAC expanded to include `deployments` and `statefulsets`
- `Dockerfile` was referencing `/bin/manager` instead of `/bin/wave`