### PR TITLE
Use image entrypoint for manager container definition

### DIFF
--- a/config/default/manager/manager.yaml
+++ b/config/default/manager/manager.yaml
@@ -41,9 +41,7 @@ spec:
         controller-tools.k8s.io: "1.0"
     spec:
       containers:
-      - command:
-        - /bin/manager
-        image: controller:latest
+      - image: controller:latest
         imagePullPolicy: Always
         name: manager
         env:


### PR DESCRIPTION
Currently, the container definition still refers to the `/bin/manager` command which got replaced with `/bin/wave` in 8f5edec223de1a90268fdfa0e6de5762f745bca0 🙂 