### PR TITLE
[IS-398] Allow optional ConfigMap / Secrets

### DIFF
--- a/pkg/controller/deployment/deployment_controller_test.go
+++ b/pkg/controller/deployment/deployment_controller_test.go
@@ -214,6 +214,7 @@ var _ = Describe("Deployment controller Suite", func() {
 
 					m.UpdateWithFunc(deployment, removeContainer2).Should(Succeed())
 					waitForDeploymentReconciled(deployment)
+					waitForDeploymentReconciled(deployment)
 
 					// Get the updated Deployment
 					m.Get(deployment, timeout).Should(Succeed())

--- a/pkg/core/children.go
+++ b/pkg/core/children.go
@@ -105,10 +105,10 @@ func getChildNamesByType(obj podController) (map[string]configMetadata, map[stri
 	// and Secrets
 	for _, vol := range obj.GetPodTemplate().Spec.Volumes {
 		if cm := vol.VolumeSource.ConfigMap; cm != nil {
-			configMaps[cm.Name] = configMetadata{required: true, allKeys: true}
+			configMaps[cm.Name] = configMetadata{required: isOptional(cm.Optional), allKeys: true}
 		}
 		if s := vol.VolumeSource.Secret; s != nil {
-			secrets[s.SecretName] = configMetadata{required: true, allKeys: true}
+			secrets[s.SecretName] = configMetadata{required: isOptional(s.Optional), allKeys: true}
 		}
 	}
 
@@ -117,10 +117,10 @@ func getChildNamesByType(obj podController) (map[string]configMetadata, map[stri
 	for _, container := range obj.GetPodTemplate().Spec.Containers {
 		for _, env := range container.EnvFrom {
 			if cm := env.ConfigMapRef; cm != nil {
-				configMaps[cm.Name] = configMetadata{required: true, allKeys: true}
+				configMaps[cm.Name] = configMetadata{required: isOptional(cm.Optional), allKeys: true}
 			}
 			if s := env.SecretRef; s != nil {
-				secrets[s.Name] = configMetadata{required: true, allKeys: true}
+				secrets[s.Name] = configMetadata{required: isOptional(s.Optional), allKeys: true}
 			}
 		}
 	}
@@ -140,6 +140,10 @@ func getChildNamesByType(obj podController) (map[string]configMetadata, map[stri
 	}
 
 	return configMaps, secrets
+}
+
+func isOptional(b *bool) bool {
+	return b == nil || !*b
 }
 
 // parseConfigMapKeyRef updates the metadata for a ConfigMap to include the keys specified in this ConfigMapKeySelector

--- a/pkg/core/children.go
+++ b/pkg/core/children.go
@@ -105,10 +105,10 @@ func getChildNamesByType(obj podController) (map[string]configMetadata, map[stri
 	// and Secrets
 	for _, vol := range obj.GetPodTemplate().Spec.Volumes {
 		if cm := vol.VolumeSource.ConfigMap; cm != nil {
-			configMaps[cm.Name] = configMetadata{required: isOptional(cm.Optional), allKeys: true}
+			configMaps[cm.Name] = configMetadata{required: isRequired(cm.Optional), allKeys: true}
 		}
 		if s := vol.VolumeSource.Secret; s != nil {
-			secrets[s.SecretName] = configMetadata{required: isOptional(s.Optional), allKeys: true}
+			secrets[s.SecretName] = configMetadata{required: isRequired(s.Optional), allKeys: true}
 		}
 	}
 
@@ -117,10 +117,10 @@ func getChildNamesByType(obj podController) (map[string]configMetadata, map[stri
 	for _, container := range obj.GetPodTemplate().Spec.Containers {
 		for _, env := range container.EnvFrom {
 			if cm := env.ConfigMapRef; cm != nil {
-				configMaps[cm.Name] = configMetadata{required: isOptional(cm.Optional), allKeys: true}
+				configMaps[cm.Name] = configMetadata{required: isRequired(cm.Optional), allKeys: true}
 			}
 			if s := env.SecretRef; s != nil {
-				secrets[s.Name] = configMetadata{required: isOptional(s.Optional), allKeys: true}
+				secrets[s.Name] = configMetadata{required: isRequired(s.Optional), allKeys: true}
 			}
 		}
 	}
@@ -142,7 +142,7 @@ func getChildNamesByType(obj podController) (map[string]configMetadata, map[stri
 	return configMaps, secrets
 }
 
-func isOptional(b *bool) bool {
+func isRequired(b *bool) bool {
 	return b == nil || !*b
 }
 

--- a/pkg/core/children_test.go
+++ b/pkg/core/children_test.go
@@ -217,11 +217,11 @@ var _ = Describe("Wave children Suite", func() {
 		})
 
 		It("optional ConfigMaps referenced in Volumes are returned as optional", func() {
-			Expect(configMaps).To(HaveKeyWithValue("example1-optional", configMetadata{required: false, allKeys: true}))
+			Expect(configMaps).To(HaveKeyWithValue("volume-optional", configMetadata{required: false, allKeys: true}))
 		})
 
 		It("optional Secrets referenced in Volumes are returned as optional", func() {
-			Expect(secrets).To(HaveKeyWithValue("example1-optional", configMetadata{required: false, allKeys: true}))
+			Expect(secrets).To(HaveKeyWithValue("volume-optional", configMetadata{required: false, allKeys: true}))
 		})
 
 		It("returns ConfigMaps referenced in EnvFrom", func() {
@@ -229,7 +229,7 @@ var _ = Describe("Wave children Suite", func() {
 		})
 
 		It("optional ConfigMaps referenced in EnvFrom are returned as optional", func() {
-			Expect(configMaps).To(HaveKeyWithValue("envfrom1-optional", configMetadata{required: false, allKeys: true}))
+			Expect(configMaps).To(HaveKeyWithValue("envfrom-optional", configMetadata{required: false, allKeys: true}))
 		})
 
 		It("returns ConfigMaps referenced in Env", func() {
@@ -245,7 +245,7 @@ var _ = Describe("Wave children Suite", func() {
 		})
 
 		It("returns ConfigMaps referenced in Env as optional correctly", func() {
-			Expect(configMaps).To(HaveKeyWithValue("env-configmap-optional", configMetadata{
+			Expect(configMaps).To(HaveKeyWithValue("env-optional", configMetadata{
 				required: false,
 				allKeys:  false,
 				keys: map[string]struct{}{
@@ -263,7 +263,7 @@ var _ = Describe("Wave children Suite", func() {
 		})
 
 		It("optional Secrets referenced in EnvFrom are returned as optional", func() {
-			Expect(secrets).To(HaveKeyWithValue("envfrom1-optional", configMetadata{required: false, allKeys: true}))
+			Expect(secrets).To(HaveKeyWithValue("envfrom-optional", configMetadata{required: false, allKeys: true}))
 		})
 
 		It("returns Secrets referenced in Env", func() {
@@ -279,7 +279,7 @@ var _ = Describe("Wave children Suite", func() {
 		})
 
 		It("returns secrets referenced in Env as optional correctly", func() {
-			Expect(secrets).To(HaveKeyWithValue("env-secret-optional", configMetadata{
+			Expect(secrets).To(HaveKeyWithValue("env-optional", configMetadata{
 				required: false,
 				allKeys:  false,
 				keys: map[string]struct{}{

--- a/pkg/core/children_test.go
+++ b/pkg/core/children_test.go
@@ -216,8 +216,20 @@ var _ = Describe("Wave children Suite", func() {
 			Expect(configMaps).To(HaveKeyWithValue(cm1.GetName(), configMetadata{required: true, allKeys: true}))
 		})
 
+		It("optional ConfigMaps referenced in Volumes are returned as optional", func() {
+			Expect(configMaps).To(HaveKeyWithValue("example1-optional", configMetadata{required: false, allKeys: true}))
+		})
+
+		It("optional Secrets referenced in Volumes are returned as optional", func() {
+			Expect(secrets).To(HaveKeyWithValue("example1-optional", configMetadata{required: false, allKeys: true}))
+		})
+
 		It("returns ConfigMaps referenced in EnvFrom", func() {
 			Expect(configMaps).To(HaveKeyWithValue(cm2.GetName(), configMetadata{required: true, allKeys: true}))
+		})
+
+		It("optional ConfigMaps referenced in EnvFrom are returned as optional", func() {
+			Expect(configMaps).To(HaveKeyWithValue("envfrom1-optional", configMetadata{required: false, allKeys: true}))
 		})
 
 		It("returns ConfigMaps referenced in Env", func() {
@@ -232,6 +244,16 @@ var _ = Describe("Wave children Suite", func() {
 			}))
 		})
 
+		It("returns ConfigMaps referenced in Env as optional correctly", func() {
+			Expect(configMaps).To(HaveKeyWithValue("env-configmap-optional", configMetadata{
+				required: false,
+				allKeys:  false,
+				keys: map[string]struct{}{
+					"key2": {},
+				},
+			}))
+		})
+
 		It("returns Secrets referenced in Volumes", func() {
 			Expect(secrets).To(HaveKeyWithValue(s1.GetName(), configMetadata{required: true, allKeys: true}))
 		})
@@ -240,8 +262,12 @@ var _ = Describe("Wave children Suite", func() {
 			Expect(secrets).To(HaveKeyWithValue(s2.GetName(), configMetadata{required: true, allKeys: true}))
 		})
 
+		It("optional Secrets referenced in EnvFrom are returned as optional", func() {
+			Expect(secrets).To(HaveKeyWithValue("envfrom1-optional", configMetadata{required: false, allKeys: true}))
+		})
+
 		It("returns Secrets referenced in Env", func() {
-			Expect(configMaps).To(HaveKeyWithValue(s3.GetName(), configMetadata{
+			Expect(secrets).To(HaveKeyWithValue(s3.GetName(), configMetadata{
 				required: true,
 				allKeys:  false,
 				keys: map[string]struct{}{
@@ -252,9 +278,19 @@ var _ = Describe("Wave children Suite", func() {
 			}))
 		})
 
+		It("returns secrets referenced in Env as optional correctly", func() {
+			Expect(secrets).To(HaveKeyWithValue("env-secret-optional", configMetadata{
+				required: false,
+				allKeys:  false,
+				keys: map[string]struct{}{
+					"key2": {},
+				},
+			}))
+		})
+
 		It("does not return extra children", func() {
-			Expect(configMaps).To(HaveLen(4))
-			Expect(secrets).To(HaveLen(4))
+			Expect(configMaps).To(HaveLen(7))
+			Expect(secrets).To(HaveLen(7))
 		})
 	})
 

--- a/test/utils/test_objects.go
+++ b/test/utils/test_objects.go
@@ -57,7 +57,7 @@ var ExampleDeployment = &appsv1.Deployment{
 						Name: "secret-optional",
 						VolumeSource: corev1.VolumeSource{
 							Secret: &corev1.SecretVolumeSource{
-								SecretName: "example1-optional",
+								SecretName: "volume-optional",
 								Optional:   &trueValue,
 							},
 						},
@@ -73,11 +73,11 @@ var ExampleDeployment = &appsv1.Deployment{
 						},
 					},
 					{
-						Name: "configmap1-optional",
+						Name: "configmap-optional",
 						VolumeSource: corev1.VolumeSource{
 							ConfigMap: &corev1.ConfigMapVolumeSource{
 								LocalObjectReference: corev1.LocalObjectReference{
-									Name: "example1-optional",
+									Name: "volume-optional",
 								},
 								Optional: &trueValue,
 							},
@@ -204,7 +204,7 @@ var ExampleDeployment = &appsv1.Deployment{
 							{
 								ConfigMapRef: &corev1.ConfigMapEnvSource{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "envfrom1-optional",
+										Name: "envfrom-optional",
 									},
 									Optional: &trueValue,
 								},
@@ -219,7 +219,7 @@ var ExampleDeployment = &appsv1.Deployment{
 							{
 								SecretRef: &corev1.SecretEnvSource{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "envfrom1-optional",
+										Name: "envfrom-optional",
 									},
 									Optional: &trueValue,
 								},
@@ -231,11 +231,11 @@ var ExampleDeployment = &appsv1.Deployment{
 						Image: "container2",
 						Env: []corev1.EnvVar{
 							{
-								Name: "example3_key2-optional",
+								Name: "env_optional_key2",
 								ValueFrom: &corev1.EnvVarSource{
 									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "env-configmap-optional",
+											Name: "env-optional",
 										},
 										Key:      "key2",
 										Optional: &trueValue,
@@ -265,11 +265,11 @@ var ExampleDeployment = &appsv1.Deployment{
 								},
 							},
 							{
-								Name: "example3_secret_key2-optional",
+								Name: "env_optional_secret_key2",
 								ValueFrom: &corev1.EnvVarSource{
 									SecretKeyRef: &corev1.SecretKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "env-secret-optional",
+											Name: "env-optional",
 										},
 										Key:      "key2",
 										Optional: &trueValue,

--- a/test/utils/test_objects.go
+++ b/test/utils/test_objects.go
@@ -54,12 +54,32 @@ var ExampleDeployment = &appsv1.Deployment{
 						},
 					},
 					{
+						Name: "secret-optional",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								SecretName: "example1-optional",
+								Optional:   &trueValue,
+							},
+						},
+					},
+					{
 						Name: "configmap1",
 						VolumeSource: corev1.VolumeSource{
 							ConfigMap: &corev1.ConfigMapVolumeSource{
 								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "example1",
 								},
+							},
+						},
+					},
+					{
+						Name: "configmap1-optional",
+						VolumeSource: corev1.VolumeSource{
+							ConfigMap: &corev1.ConfigMapVolumeSource{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "example1-optional",
+								},
+								Optional: &trueValue,
 							},
 						},
 					},
@@ -182,10 +202,26 @@ var ExampleDeployment = &appsv1.Deployment{
 								},
 							},
 							{
+								ConfigMapRef: &corev1.ConfigMapEnvSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "envfrom1-optional",
+									},
+									Optional: &trueValue,
+								},
+							},
+							{
 								SecretRef: &corev1.SecretEnvSource{
 									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "example1",
 									},
+								},
+							},
+							{
+								SecretRef: &corev1.SecretEnvSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "envfrom1-optional",
+									},
+									Optional: &trueValue,
 								},
 							},
 						},
@@ -194,6 +230,18 @@ var ExampleDeployment = &appsv1.Deployment{
 						Name:  "container2",
 						Image: "container2",
 						Env: []corev1.EnvVar{
+							{
+								Name: "example3_key2-optional",
+								ValueFrom: &corev1.EnvVarSource{
+									ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "env-configmap-optional",
+										},
+										Key:      "key2",
+										Optional: &trueValue,
+									},
+								},
+							},
 							{
 								Name: "example3_key2",
 								ValueFrom: &corev1.EnvVarSource{
@@ -213,6 +261,18 @@ var ExampleDeployment = &appsv1.Deployment{
 											Name: "example3",
 										},
 										Key: "key2",
+									},
+								},
+							},
+							{
+								Name: "example3_secret_key2-optional",
+								ValueFrom: &corev1.EnvVarSource{
+									SecretKeyRef: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "env-secret-optional",
+										},
+										Key:      "key2",
+										Optional: &trueValue,
 									},
 								},
 							},


### PR DESCRIPTION
It's possible to specify Secrets and ConfigMaps as `optional` for a Deployment (and potentially other resource types), and Wave appears to have support for this with regards to values in the `EnvFrom` section, but not when mounting a Secret or ConfigMap.

This allows secrets and config maps mounted from a `Volume`,  `EnvFrom` or `Env` to be optional.