### PR TITLE
Adjust resource requests

### DIFF
--- a/config/default/manager/manager.yaml
+++ b/config/default/manager/manager.yaml
@@ -54,10 +54,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 75Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 75Mi
         ports:
         - containerPort: 9876
           name: webhook-server


### PR DESCRIPTION
With just 20Mi request/30Mi limits, my instance of the wave controller running in a Kubernetes cluster with only ~50 pods never really started. It was already stuck at the log line `Starting metrics server`.

Running the application locally in the debugger worked fine. The issue turned out to be starvation in garbage collection. Slightly increasing the memory requests resolved the issue entirely.

Experiments allowed stable (but slow) operations starting with 40Mi requests/limits; with 75Mi wave starts and performs required operations within few seconds. Proposing to set request=limit to get into guaranteed QoS class.