### PR TITLE
Disable metrics across tests and run in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ check: fmt lint vet test
 .PHONY: test
 test: vendor generate manifests
 	@ echo "\033[36mRunning test suite in Ginkgo\033[0m"
-	$(GINKGO) -v -race -randomizeAllSpecs ./pkg/... ./cmd/... -- -report-dir=$$ARTIFACTS
+	$(GINKGO) -v -p -race -randomizeAllSpecs ./pkg/... ./cmd/... -- -report-dir=$$ARTIFACTS
 	@ echo
 
 # Build manager binary

--- a/pkg/controller/daemonset/daemonset_controller_test.go
+++ b/pkg/controller/daemonset/daemonset_controller_test.go
@@ -75,7 +75,9 @@ var _ = Describe("DaemonSet controller Suite", func() {
 		// Reset the Prometheus Registry before each test to avoid errors
 		metrics.Registry = prometheus.NewRegistry()
 
-		mgr, err := manager.New(cfg, manager.Options{})
+		mgr, err := manager.New(cfg, manager.Options{
+			MetricsBindAddress: "0",
+		})
 		Expect(err).NotTo(HaveOccurred())
 		c = mgr.GetClient()
 		m = utils.Matcher{Client: c}

--- a/pkg/controller/deployment/deployment_controller_test.go
+++ b/pkg/controller/deployment/deployment_controller_test.go
@@ -75,7 +75,9 @@ var _ = Describe("Deployment controller Suite", func() {
 		// Reset the Prometheus Registry before each test to avoid errors
 		metrics.Registry = prometheus.NewRegistry()
 
-		mgr, err := manager.New(cfg, manager.Options{})
+		mgr, err := manager.New(cfg, manager.Options{
+			MetricsBindAddress: "0",
+		})
 		Expect(err).NotTo(HaveOccurred())
 		c = mgr.GetClient()
 		m = utils.Matcher{Client: c}

--- a/pkg/controller/statefulset/statefulset_controller_test.go
+++ b/pkg/controller/statefulset/statefulset_controller_test.go
@@ -75,7 +75,9 @@ var _ = Describe("StatefulSet controller Suite", func() {
 		// Reset the Prometheus Registry before each test to avoid errors
 		metrics.Registry = prometheus.NewRegistry()
 
-		mgr, err := manager.New(cfg, manager.Options{})
+		mgr, err := manager.New(cfg, manager.Options{
+			MetricsBindAddress: "0",
+		})
 		Expect(err).NotTo(HaveOccurred())
 		c = mgr.GetClient()
 		m = utils.Matcher{Client: c}

--- a/pkg/core/children_test.go
+++ b/pkg/core/children_test.go
@@ -53,7 +53,9 @@ var _ = Describe("Wave children Suite", func() {
 	var s4 *corev1.Secret
 
 	BeforeEach(func() {
-		mgr, err := manager.New(cfg, manager.Options{})
+		mgr, err := manager.New(cfg, manager.Options{
+			MetricsBindAddress: "0",
+		})
 		Expect(err).NotTo(HaveOccurred())
 		c = mgr.GetClient()
 		h = NewHandler(c, mgr.GetEventRecorderFor("wave"))

--- a/pkg/core/delete_test.go
+++ b/pkg/core/delete_test.go
@@ -48,7 +48,9 @@ var _ = Describe("Wave owner references Suite", func() {
 	var ownerRef metav1.OwnerReference
 
 	BeforeEach(func() {
-		mgr, err := manager.New(cfg, manager.Options{})
+		mgr, err := manager.New(cfg, manager.Options{
+			MetricsBindAddress: "0",
+		})
 		Expect(err).NotTo(HaveOccurred())
 		c = mgr.GetClient()
 		h = NewHandler(c, mgr.GetEventRecorderFor("wave"))

--- a/pkg/core/handler_test.go
+++ b/pkg/core/handler_test.go
@@ -57,7 +57,9 @@ var _ = Describe("Wave controller Suite", func() {
 	var modified = "modified"
 
 	BeforeEach(func() {
-		mgr, err := manager.New(cfg, manager.Options{})
+		mgr, err := manager.New(cfg, manager.Options{
+			MetricsBindAddress: "0",
+		})
 		Expect(err).NotTo(HaveOccurred())
 		c = mgr.GetClient()
 		h = NewHandler(c, mgr.GetEventRecorderFor("wave"))

--- a/pkg/core/hash_test.go
+++ b/pkg/core/hash_test.go
@@ -49,7 +49,9 @@ var _ = Describe("Wave hash Suite", func() {
 		var modified = "modified"
 
 		BeforeEach(func() {
-			mgr, err := manager.New(cfg, manager.Options{})
+			mgr, err := manager.New(cfg, manager.Options{
+				MetricsBindAddress: "0",
+			})
 			Expect(err).NotTo(HaveOccurred())
 			c = mgr.GetClient()
 			m = utils.Matcher{Client: c}

--- a/pkg/core/owner_references_test.go
+++ b/pkg/core/owner_references_test.go
@@ -51,7 +51,9 @@ var _ = Describe("Wave owner references Suite", func() {
 	var ownerRef metav1.OwnerReference
 
 	BeforeEach(func() {
-		mgr, err := manager.New(cfg, manager.Options{})
+		mgr, err := manager.New(cfg, manager.Options{
+			MetricsBindAddress: "0",
+		})
 		Expect(err).NotTo(HaveOccurred())
 		c = mgr.GetClient()
 		h = NewHandler(c, mgr.GetEventRecorderFor("wave"))


### PR DESCRIPTION
This disables metrics serving within tests which means they can then be run in parallel.

It then adds the `p` flag to ginkgo in make test to make tests run in parallel automatically using (I think) all but one thread on the machine.

Hoping this will make tests run faster within CI though not sure what the real impact would be, opening this PR as a sort of test of the performance