### PR TITLE
Fix build issues on macOS and general build improvements

### DIFF
--- a/Makefile.tools
+++ b/Makefile.tools
@@ -27,7 +27,7 @@ ginkgo-cli:
 .PHONY: golangci-lint
 golangci-lint:
 	@ if [ ! $$(which golangci-lint) ]; then \
-		curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.15.0; \
+		curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $$(go env GOPATH)/bin v1.15.0; \
 	fi
 
 .PHONY: kustomize

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -1,7 +1,7 @@
 .PHONY: prepare-env-%
 prepare-env-%: gopath dep ginkgo-cli golangci-lint kustomize
-	PATH=$$GOPATH/bin:/usr/local/kubebuilder-$*/bin:$$PATH make kubebuilder-tools-$*
-	PATH=$$GOPATH/bin:/usr/local/kubebuilder-$*/bin:$$PATH ./configure
+	PATH=$$GOPATH/bin:/usr/local/kubebuilder-$*/bin:/usr/local/opt/kubebuilder-$*/bin:$$PATH make kubebuilder-tools-$*
+	PATH=$$GOPATH/bin:/usr/local/kubebuilder-$*/bin:/usr/local/opt/kubebuilder-$*/bin:$$PATH ./configure
 
 .PHONY: gopath
 gopath:
@@ -78,7 +78,7 @@ install-kubebuilder-tools:
 	tar -zxvf kubebuilder_$(kubebuilder_version_string).tar.gz
 	rm kubebuilder_$(kubebuilder_version_string).tar.gz
 
-	export TEST_ASSET_DIR=/usr/local/kubebuilder-${kubernetes_version}/bin; \
+	export TEST_ASSET_DIR=/usr/local/opt/kubebuilder-${kubernetes_version}/bin; \
 	export TEST_ASSET_KUBECTL=$$TEST_ASSET_DIR/kubectl \
 	TEST_ASSET_KUBE_APISERVER=$$TEST_ASSET_DIR/kube-apiserver \
 	TEST_ASSET_ETCD=$$TEST_ASSET_DIR/etcd \

--- a/configure
+++ b/configure
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
 if (( ${BASH_VERSION:0:1} < 4 )); then
-  echo "This configure script requires bash 4"
+  echo "This configure script requires at least Bash 4"
+  if [[ "$OSTYPE" == darwin* ]]; then
+    echo "On macOS, you can upgrade it using Homebrew <https://brew.sh/> by typing: brew install bash"
+  fi
   exit 1
 fi
 


### PR DESCRIPTION
This PR addresses the issues found in #46. In particular:
- the `configure` script depends on bash 4, but gave a particularly bland message. This makes it print a special message for `macOS` users suggesting how to upgrade `bash` to version 4 (as by default macOS ships with version 3)
- The task `golangci-lint` in `Makefile.tools` had a missing `$` in a shell evaluation leading to an incorrect path being used for the linting tool
- `kubebuilder` is now being installed in `/usr/local/opt` instead of `/usr/local` by default as that directory is writable by default on macOS.

\o/ Hacktoberfest!